### PR TITLE
Contextually aware popup w/ tabs, dark theme moved, and multiple bug fixes.

### DIFF
--- a/design-manager.js
+++ b/design-manager.js
@@ -1,46 +1,45 @@
-$(document).ready(function(){
-	/*This script runs once the design manager page loads.*/
-		var tabUrl =window.location.protocol + "//" + window.location.host + "/" + window.location.pathname;
-			/*getSelected might be deprecated need to review*/
-			
-			//console.log("Current URL: ",tabUrl);
-			if(~tabUrl.indexOf("app.hubspot.com")){
-				//console.log("This is the hubspot backend.");
-				
-				
-				if(~tabUrl.indexOf("/design-manager/")){
-					//console.log("Old Design Manager is active");
-				
-				}
-				if(~tabUrl.indexOf("/beta-design-manager/")){
-					/*note this string detection will likely break once rolled out to everyone as they likely wont leave beta in the name*/
-					//console.log("Design Manager V2 is active");
-					chrome.storage.sync.get([
-					    'darktheme'
-					  ], function(items) {
-					    if(items.darktheme){
-					    	$("body").addClass("ext-dark-theme");
-					    }
-					});
-				
-				}
-				
-			}
-			else if(~tabUrl.indexOf("designers.hubspot.com/docs/")){
-				//console.log("Viewing HubSpot Documentation");
-				
-				
-			}
-			else{
-				//console.log("This is not in the HubSpot Backend");
-				
+$(document).ready(function() {
+    /*This script runs once the design manager page loads.*/
+    var tabUrl = window.location.protocol + "//" + window.location.host + "/" + window.location.pathname;
+    /*getSelected might be deprecated need to review*/
 
-			}
-			
+    //console.log("Current URL: ",tabUrl);
+    if (~tabUrl.indexOf("app.hubspot.com")) {
+        //console.log("This is the hubspot backend.");
 
-	
 
-	
-	
+        if (~tabUrl.indexOf("/design-manager/")) {
+            //console.log("Old Design Manager is active");
+
+        }
+        if (~tabUrl.indexOf("/beta-design-manager/")) {
+            /*note this string detection will likely break once rolled out to everyone as they likely wont leave beta in the name*/
+            //console.log("Design Manager V2 is active");
+            chrome.storage.sync.get([
+                'darktheme'
+            ], function(items) {
+                if (items.darktheme) {
+                    $("body").addClass("ext-dark-theme");
+                }
+            });
+
+        }
+
+    } else if (~tabUrl.indexOf("designers.hubspot.com/docs/")) {
+        //console.log("Viewing HubSpot Documentation");
+
+
+    } else {
+        //console.log("This is not in the HubSpot Backend");
+
+
+    }
+
+
+
+
+
+
+
 
 });

--- a/design-manager.js
+++ b/design-manager.js
@@ -1,12 +1,46 @@
 $(document).ready(function(){
 	/*This script runs once the design manager page loads.*/
-	
-	chrome.storage.sync.get([
-	    'darktheme'
-	  ], function(items) {
-	    if(items.darktheme){
-	    	$("body").addClass("ext-dark-theme");
-	    }
-	});
+		var tabUrl =window.location.protocol + "//" + window.location.host + "/" + window.location.pathname;
+			/*getSelected might be deprecated need to review*/
+			
+			//console.log("Current URL: ",tabUrl);
+			if(~tabUrl.indexOf("app.hubspot.com")){
+				//console.log("This is the hubspot backend.");
+				
+				
+				if(~tabUrl.indexOf("/design-manager/")){
+					//console.log("Old Design Manager is active");
+				
+				}
+				if(~tabUrl.indexOf("/beta-design-manager/")){
+					/*note this string detection will likely break once rolled out to everyone as they likely wont leave beta in the name*/
+					//console.log("Design Manager V2 is active");
+					chrome.storage.sync.get([
+					    'darktheme'
+					  ], function(items) {
+					    if(items.darktheme){
+					    	$("body").addClass("ext-dark-theme");
+					    }
+					});
+				
+				}
+				
+			}
+			else if(~tabUrl.indexOf("designers.hubspot.com/docs/")){
+				//console.log("Viewing HubSpot Documentation");
+				
+				
+			}
+			else{
+				//console.log("This is not in the HubSpot Backend");
+				
 
-})
+			}
+			
+
+	
+
+	
+	
+
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "HubSpot Developer Extension ",
-	"version": "1.01.1",
+	"version": "1.02",
 	"description": "A HubSpot Developers Sidekick Extension",
 	"permissions": ["declarativeContent", "storage"],
 	"browser_action": {

--- a/options.html
+++ b/options.html
@@ -3,15 +3,10 @@
 <head><title>Options page</title></head>
 <body>
 	<p>We apologize for the blandness of this screen, but if you'd like to help make it look better, you can help!</p>
-	<br>
+	
 	<p><a href="https://github.com/williamspiro/HubSpot-Developer-Extension/">View on GitHub</a></p>
-	<label>
-	  <input type="checkbox" id="darktheme">
-	  Activate dark theme in the new IDE
-	</label>
-
-	<div id="status"></div>
-	<button id="save">Save</button>
+	<p><a href="https://github.com/williamspiro/HubSpot-Developer-Extension/releases">View Change Log</a></p>
+	<br>Note: if you're looking for the dark theme toggle, we've moved it! It's now in the Develop tab when you open the extension.
 	<br><br>
 	<p>This Extension is not directly affiliated with HubSpot, we claim no rights to any of the HubSpot Trademarks.</p>
 	<p>Developed by:

--- a/options.html
+++ b/options.html
@@ -6,8 +6,10 @@
 	
 	<p><a href="https://github.com/williamspiro/HubSpot-Developer-Extension/">View on GitHub</a></p>
 	<p><a href="https://github.com/williamspiro/HubSpot-Developer-Extension/releases">View Change Log</a></p>
-	<br>Note: if you're looking for the dark theme toggle, we've moved it! It's now in the Develop tab when you open the extension.
-	<br><br>
+	<p>If you like the extension <a href="https://chrome.google.com/webstore/detail/hubspot-developer-extensi/gebemkdecnlgbcanplbgdpcffpdnfdfo/reviews">please rate</a> so others can find it! If there's an area where we could do better, let us know in the <a href="https://github.com/williamspiro/HubSpot-Developer-Extension/issues">github issues</a> or using the <a href="https://chrome.google.com/webstore/detail/hubspot-developer-extensi/gebemkdecnlgbcanplbgdpcffpdnfdfo/support">support/feedback feature</a> on the chrome web store(don't use reviews for that).</p>
+	<p>Note: if you're looking for the dark theme toggle, we've moved it! It's now in the Develop tab when you open the extension.
+		</p>
+	<br>
 	<p>This Extension is not directly affiliated with HubSpot, we claim no rights to any of the HubSpot Trademarks.</p>
 	<p>Developed by:
 		<ul>

--- a/popup.html
+++ b/popup.html
@@ -18,6 +18,7 @@
     font-size: .875rem;
     display: inline-block;
     vertical-align: middle;
+    color:#fff;
 }
 .private-form__toggle-switch {
     -webkit-user-select: none;
@@ -173,6 +174,8 @@ input:checked ~ .private-form__toggle-switch__icon,{
     left: 100%;
     transform: translateX(-100%);
 }
+
+#status{color:#fff;}
 
     /*To keep CSS organized and easy to understand this css is following this method https://css-tricks.com/combining-the-powers-of-sem-and-bio-for-improving-css/
 Do not let fear of learning a new technique prevent you from contributing, others can help convert your css to fit this flow. so pull request even if it doesn't fit this way of doing things. The important thing is that it works, keeping organized and understandable is second. If everyone finds they hate writing CSS this way we can work out another way to do it.

--- a/popup.html
+++ b/popup.html
@@ -224,7 +224,7 @@ Do not let fear of learning a new technique prevent you from contributing, other
                 </div>
             </div>
         </div>
-        <div class="c-tab-slide" id="design-manager">
+        <div class="c-tab-slider__tab" id="design-manager">
             <!-- this tab will be focused while the user is in the design manager any features intended only for DM1 or DM2 should get disabled if they do not work in the current version of the design manager -->
             <div class="c-btn c-btn--docs face-button" id="docs">
                 <div class="c-btn__face-primary">Documentation</div>

--- a/popup.html
+++ b/popup.html
@@ -1,268 +1,260 @@
-<style>
-/*To keep CSS organized and easy to understand this css is following this method https://css-tricks.com/combining-the-powers-of-sem-and-bio-for-improving-css/
+<html>
+
+<head>
+    <title></title>
+    <style>
+    /*To keep CSS organized and easy to understand this css is following this method https://css-tricks.com/combining-the-powers-of-sem-and-bio-for-improving-css/
 Do not let fear of learning a new technique prevent you from contributing, others can help convert your css to fit this flow. so pull request even if it doesn't fit this way of doing things. The important thing is that it works, keeping organized and understandable is second. If everyone finds they hate writing CSS this way we can work out another way to do it.
 */
+    /*Settings - variables that do not generate visual styles on their own*/
+
+     :root {
+        --buttonColor: #ff7a59;
+    }
+
+     :focus {
+        outline: none;
+    }
+    /*Objects - (namespace: o-) are used for design patterns, such as layouts, where items are being arranged rather than decorated. */
+
+    .o-menu-grid {
+        display: grid;
+        grid-gap: 5px;
+        width: 100%;
+        grid-template-columns: 1fr 1fr;
+        grid-template-areas: "debug bustcache" "movejquery amp" "psrequest psrequest" "docs docs";
+    }
+
+    #hsDebug {
+        grid-area: debug;
+    }
+
+    #hsMoveJQueryToFooter {
+        grid-area: movejquery;
+    }
+
+    #hs_amp {
+        grid-area: amp;
+    }
+
+    #bustCache {
+        grid-area: bustcache;
+    }
+
+    #psiScoreRequest {
+        grid-area: psrequest;
+    }
+
+    #docs {
+        grid-area: docs;
+    }
 
 
-/*Settings - variables that do not generate visual styles on their own*/
+    .column_2 {
+        float: left;
+        width: 50%;
+    }
 
- :root {
-    --buttonColor: #ff7a59;
-}
+    .row:after {
+        content: "";
+        display: table;
+        clear: both;
+    }
+    /*Elements - HTML native elements default styles without classes*/
 
- :focus {
-    outline: none;
-}
+    * {
+        box-sizing: border-box;
+    }
 
+    body {
+        width: 391px;
+        color: cornflowerblue;
+        background-color: #33475b;
+        background: linear-gradient(45deg, #33475b, #2d3e50);
+        margin: 5px;
+        /*evens context menu spacing to match grid gap*/
+    }
 
-/*Objects - (namespace: o-) are used for design patterns, such as layouts, where items are being arranged rather than decorated. */
+    img {
+        max-width: 100%;
+        height: auto;
+    }
+    /*Components - (namespace: c-) is a small feature that makes up a part of the website/extension. Think buttons, accordions, sliders, modal dialogs, etc. Each component is fully functional by itself and does not rely on any other components. This fact should be considered when you name the component.*/
 
-.o-menu-grid {
-    display: grid;
-    grid-gap: 5px;
-    width: 100%;
-    grid-template-columns: 1fr 1fr;
-    grid-template-areas: "debug bustcache" "movejquery amp" "psrequest psrequest" "docs docs";
-}
-
-#hsDebug {
-    grid-area: debug;
-}
-
-#hsMoveJQueryToFooter {
-    grid-area: movejquery;
-}
-
-#hs_amp {
-    grid-area: amp;
-}
-
-#bustCache {
-    grid-area: bustcache;
-}
-
-#psiScoreRequest {
-    grid-area: psrequest;
-}
-
-#docs {
-    grid-area: docs;
-}
-
-
-.column_2 {
-    float: left;
-    width: 50%;
-}
-
-.row:after {
-    content: "";
-    display: table;
-    clear: both;
-}
-
-
-/*Elements - HTML native elements default styles without classes*/
-
-* {
-    box-sizing: border-box;
-}
-
-body {
-    width: 391px;
-    color: cornflowerblue;
-    background-color: #33475b;
-    background: linear-gradient(45deg, #33475b, #2d3e50);
-    margin: 5px;
-    /*evens context menu spacing to match grid gap*/
-}
-
-img {
-    max-width: 100%;
-    height: auto;
-}
-
-
-/*Components - (namespace: c-) is a small feature that makes up a part of the website/extension. Think buttons, accordions, sliders, modal dialogs, etc. Each component is fully functional by itself and does not rely on any other components. This fact should be considered when you name the component.*/
-
-.c-btn {
-    padding: 0;
-    height: 44px;
-    display: block;
-    width: 100%;
-    border: 3px solid var(--buttonColor);
-    font-size: 14px;
-    text-align: center;
-    text-decoration: none;
-    overflow: hidden;
-    cursor: pointer;
-    -webkit-appearance: none;
-    background-color: #fff;
-}
+    .c-btn {
+        padding: 0;
+        height: 44px;
+        display: block;
+        width: 100%;
+        border: 3px solid var(--buttonColor);
+        font-size: 14px;
+        text-align: center;
+        text-decoration: none;
+        overflow: hidden;
+        cursor: pointer;
+        -webkit-appearance: none;
+        background-color: #fff;
+    }
 
 
 
 
-.c-btn__face-primary,
-.c-btn__face-secondary {
-    display: block;
-    padding: 0 22px;
-    line-height: 39px;
-    transition: margin 0.4s;
-}
+    .c-btn__face-primary,
+    .c-btn__face-secondary {
+        display: block;
+        padding: 0 22px;
+        line-height: 39px;
+        transition: margin 0.4s;
+    }
 
-.c-btn__face-primary {
-    background-color: var(--buttonColor);
-    color: #fff;
-}
+    .c-btn__face-primary {
+        background-color: var(--buttonColor);
+        color: #fff;
+    }
 
-.c-btn__face-secondary {
-    font-size: 13px;
-    padding: 0 0;
-}
+    .c-btn__face-secondary {
+        font-size: 13px;
+        padding: 0 0;
+    }
 
-.c-btn:not(.c-btn--graded):hover .c-btn__face-primary,
-.c-btn:not(.c-btn--graded):focus .c-btn__face-primary {
-    margin-top: -39px;
-}
-
-
-.c-btn__psiScore {
-    display: none;
-    text-align: center;
-}
-
-.c-btn__grades {
-    font-size: 33px;
-    padding: 16px;
-    color: #e43;
-}
-
-.c-btn__score {
-    /*update js*/
-    font-size: 40px;
-    display: block;
-    font-weight: bold;
-}
+    .c-btn:not(.c-btn--graded):hover .c-btn__face-primary,
+    .c-btn:not(.c-btn--graded):focus .c-btn__face-primary {
+        margin-top: -39px;
+    }
 
 
-/*Scopes - The purpose of the scope (namespace: s-) is to give us the highest specificity so we can overwrite any styles for a specific purpose.
+    .c-btn__psiScore {
+        display: none;
+        text-align: center;
+    }
+
+    .c-btn__grades {
+        font-size: 33px;
+        padding: 16px;
+        color: #e43;
+    }
+
+    .c-btn__score {
+        /*update js*/
+        font-size: 40px;
+        display: block;
+        font-weight: bold;
+    }
+    /*Scopes - The purpose of the scope (namespace: s-) is to give us the highest specificity so we can overwrite any styles for a specific purpose.
 
 */
 
-.c-tab-slider {
-    width: 100vw;
-}
+    .c-tab-slider {
+        width: 100vw;
+    }
 
-.c-btn--graded {
-    /*update js to update the class it adds*/
-    overflow: initial;
-    height: initial;
-    /*background-image: url(https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/pagespeed-logo.png);*/
-    background-size: contain;
-    background-position: center bottom;
-    background-repeat: no-repeat;
-    background-size: 150px;
-}
+    .c-btn--graded {
+        /*update js to update the class it adds*/
+        overflow: initial;
+        height: initial;
+        /*background-image: url(https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/pagespeed-logo.png);*/
+        background-size: contain;
+        background-position: center bottom;
+        background-repeat: no-repeat;
+        background-size: 150px;
+    }
 
-.c-btn--graded .c-btn__face-secondary {
-    display: none;
-}
+    .c-btn--graded .c-btn__face-secondary {
+        display: none;
+    }
 
-.c-btn--docs {
-    cursor: unset;
-}
+    .c-btn--docs {
+        cursor: unset;
+    }
 
-.c-btn--docs .c-btn__face-secondary {
-    display: flex;
-    align-items: center;
-    justify-content: space-around;
-}
+    .c-btn--docs .c-btn__face-secondary {
+        display: flex;
+        align-items: center;
+        justify-content: space-around;
+    }
 
-.c-btn--docs a {
-    padding: 0 10px;
-}
+    .c-btn--docs a {
+        padding: 0 10px;
+    }
 
-.c-btn--docs a:hover,
-.c-btn--docs a:focus {
-    color: var(--buttonColor);
-}
-
-
-/*Utility - Sometimes you may want to make changes only for a certain style in a specific place. In that case, utility (namespace: u-) classes can help us update it without changing the whole CSS structure.*/
-
-
-/*state and JS namespaces
+    .c-btn--docs a:hover,
+    .c-btn--docs a:focus {
+        color: var(--buttonColor);
+    }
+    /*Utility - Sometimes you may want to make changes only for a certain style in a specific place. In that case, utility (namespace: u-) classes can help us update it without changing the whole CSS structure.*/
+    /*state and JS namespaces
 * is-: this indicates the state of the block or element. Most commonly used class is .is-active, like the active link in navigation. */
+    /*hide Debug mode button, bust cache button, footer jquery, google page speed, when viewing site backend*/
 
+    body.is-backend .u-hidden-backend {
+        display: none;
+    }
 
-/*hide Debug mode button, bust cache button, footer jquery, google page speed, when viewing site backend*/
+    body.is-dm1 .u-hidden-dm1 {
+        display: none;
+    }
 
-body.is-backend .u-hidden-backend {
-    display: none;
-}
+    body.is-dm2 .u-hidden-dm2 {
+        display: none;
+    }
 
-body.is-dm1 .u-hidden-dm1 {
-    display: none;
-}
+    body.is-hs-docs .u-hidden-hs-docs {
+        display: none;
+    }
+    /*js-: this indicates that the specific element is bound to JavaScript events. For example, js-menu-click indicates that the element is bound to the click event. generally JS classes are only added to the html, as they are for targeting with JS not affecting actual styles.*/
+    </style>
+</head>
 
-body.is-dm2 .u-hidden-dm2 {
-    display: none;
-}
-
-body.is-hs-docs .u-hidden-hs-docs {
-    display: none;
-}
-
-
-/*js-: this indicates that the specific element is bound to JavaScript events. For example, js-menu-click indicates that the element is bound to the click event. generally JS classes are only added to the html, as they are for targeting with JS not affecting actual styles.*/
-</style>
-<div class="c-tab-slider">
-    <div class="c-tab-slider__tab" id="debug-tools">
-        <!--This tab will be focused when the user is not in the design manager -->
-        <div class="o-menu-grid">
-            <button class="c-btn face-button js-click--debug" id="hsDebug">
-                <div class="c-btn__face-primary">Debug Mode</div>
-                <div class="c-btn__face-secondary">hsDebug=True</div>
-            </button>
-            <button class="c-btn face-button js-click--bust-cache" id="cacheBuster">
-                <div class="c-btn__face-primary">Bust Cache</div>
-                <div class="c-btn__face-secondary">bustCache=[random Number]</div>
-            </button>
-            <button class="c-btn face-button js-click--move-jquery-to-footer" id="hsMoveJQueryToFooter">
-                <div class="c-btn__face-primary">Footer jQuery</div>
-                <div class="c-btn__face-secondary">hsMoveJQueryToFooter=True</div>
-            </button>
-            <button class="c-btn face-button js-click--amp" id="hs_amp">
-                <div class="c-btn__face-primary">Amp</div>
-                <div class="c-btn__face-secondary">hs_amp=true</div>
-            </button>
-            <button class="c-btn face-button js-click--psi-score-request" id="psiScoreRequest">
-                <div class="c-btn__face-primary">Google Page Speed Insights Scores</div>
-                <div class="c-btn__face-secondary">Score Me!
-                    <!--<img style="height: 39px;" src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/pagespeed.png">--></div>
-                <div class="row c-btn__grades">
-                    <div class="c-btn__psiScore column_2" id="desktop_psi_placeholder">grading desktop...
-                        <!--<img src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/NewCorgiDance.gif">--></div>
-                    <div class="c-btn__psiScore column_2" id="mobile_psi_placeholder">grading mobile...
-                        <!--<img src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/NewCorgiDance.gif">--></div>
-                </div>
-            </button>
+<body>
+    <div class="c-tab-slider">
+        <div class="c-tab-slider__tab" id="debug-tools">
+            <!--This tab will be focused when the user is not in the design manager -->
+            <div class="o-menu-grid">
+                <button class="c-btn face-button js-click--debug" id="hsDebug">
+                    <div class="c-btn__face-primary">Debug Mode</div>
+                    <div class="c-btn__face-secondary">hsDebug=True</div>
+                </button>
+                <button class="c-btn face-button js-click--bust-cache" id="cacheBuster">
+                    <div class="c-btn__face-primary">Bust Cache</div>
+                    <div class="c-btn__face-secondary">bustCache=[random Number]</div>
+                </button>
+                <button class="c-btn face-button js-click--move-jquery-to-footer" id="hsMoveJQueryToFooter">
+                    <div class="c-btn__face-primary">Footer jQuery</div>
+                    <div class="c-btn__face-secondary">hsMoveJQueryToFooter=True</div>
+                </button>
+                <button class="c-btn face-button js-click--amp" id="hs_amp">
+                    <div class="c-btn__face-primary">Amp</div>
+                    <div class="c-btn__face-secondary">hs_amp=true</div>
+                </button>
+                <button class="c-btn face-button js-click--psi-score-request" id="psiScoreRequest">
+                    <div class="c-btn__face-primary">Google Page Speed Insights Scores</div>
+                    <div class="c-btn__face-secondary">Score Me!
+                        <!--<img style="height: 39px;" src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/pagespeed.png">--></div>
+                    <div class="row c-btn__grades">
+                        <div class="c-btn__psiScore column_2" id="desktop_psi_placeholder">grading desktop...
+                            <!--<img src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/NewCorgiDance.gif">--></div>
+                        <div class="c-btn__psiScore column_2" id="mobile_psi_placeholder">grading mobile...
+                            <!--<img src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/NewCorgiDance.gif">--></div>
+                    </div>
+                </button>
+            </div>
         </div>
-    </div>
-    <div class="c-tab-slider__tab" id="design-manager">
-        <!-- this tab will be focused while the user is in the design manager any features intended only for DM1 or DM2 should get disabled if they do not work in the current version of the design manager -->
-        <div class="c-btn c-btn--docs face-button" id="docs">
-            <div class="c-btn__face-primary">Documentation</div>
-            <div class="c-btn__face-secondary">
-                <a target="blank" href="https://designers.hubspot.com/en/docs/hubl/hubl-supported-functions">Functions<!--add opens in new window icon--></a>
-                <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-variables">Variables<!--add opens in new window icon--></a> <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-filters">Filters<!--add opens in new window icon--></a>
-                <a target="blank" href=" https://designers.hubspot.com/docs/tools/hubdb">HubDB<!--add opens in new window icon--></a>
+        <div class="c-tab-slider__tab" id="design-manager">
+            <!-- this tab will be focused while the user is in the design manager any features intended only for DM1 or DM2 should get disabled if they do not work in the current version of the design manager -->
+            <div class="c-btn c-btn--docs face-button" id="docs">
+                <div class="c-btn__face-primary">Documentation</div>
+                <div class="c-btn__face-secondary">
+                    <a target="blank" href="https://designers.hubspot.com/en/docs/hubl/hubl-supported-functions">Functions<!--add opens in new window icon--></a>
+                    <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-variables">Variables<!--add opens in new window icon--></a> <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-filters">Filters<!--add opens in new window icon--></a>
+                    <a target="blank" href=" https://designers.hubspot.com/docs/tools/hubdb">HubDB<!--add opens in new window icon--></a>
+                </div>
             </div>
         </div>
     </div>
-</div>
-<!--  <button id="psiScoreRequest" class="debugButton">Grade my page</button>
+    <!--  <button id="psiScoreRequest" class="debugButton">Grade my page</button>
  -->
-<script src="jquery-3.2.1.min.js"></script>
-<script src="popup.js"></script>
+    <script src="jquery-3.2.1.min.js"></script>
+    <script src="popup.js"></script>
+</body>
+
+</html>

--- a/popup.html
+++ b/popup.html
@@ -307,6 +307,16 @@ Do not let fear of learning a new technique prevent you from contributing, other
                             <a target="blank" href=" https://designers.hubspot.com/docs/tools/hubdb">HubDB<!--add opens in new window icon--></a>
                         </div>
                     </div>
+                    <div class="setting-wrapper">
+                      <label>
+                        <input type="checkbox" id="darktheme">
+                        Activate dark theme in the new IDE
+                      </label>
+
+                      <div id="status"></div>
+                      <button id="save">Save</button>
+                    </div>
+
                 </div>
             </div>
         </div>

--- a/popup.html
+++ b/popup.html
@@ -3,184 +3,221 @@
 <head>
     <title></title>
     <style>
-
-
     /*checkbox input stolen from HS, we really should switch this to be a normal css checkbox, the html and css is over the top*/
+
     .private-form__label--small {
-    font-size: 12px;
-    font-size: .75rem;
-}
-.private-form__label {
-    padding: .5rem .75rem .25rem 0;
-    font-family: Avenir Next W02,Helvetica,Arial,sans-serif;
-    font-weight: 500;
-    font-size: 14px;
-    font-size: .875rem;
-    display: inline-block;
-    vertical-align: middle;
-    color:#fff;
-}
-.private-form__toggle-switch {
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    cursor: pointer;
-    display: inline-block;
-    vertical-align: middle;
-}
-.sr-only {
-    position: absolute!important;
-    width: 1px!important;
-    height: 1px!important;
-    margin: -1px!important;
-    padding: 0!important;
-    overflow: hidden!important;
-    clip: rect(0,0,0,0)!important;
-    border: 0!important;
-}
-.private-form__toggle-switch--sm .private-form__toggle-switch__inner:not(.private-form__toggle-switch--on), .private-form__toggle-switch--xs .private-form__toggle-switch__inner:not(.private-form__toggle-switch--on) {
-    background-color: #f5f8fa;
-}
-.private-form__toggle-switch--xs .private-form__toggle-switch__handle, .private-form__toggle-switch--xs .private-form__toggle-switch__inner {
-    height: 26px;
-}
-.private-form__toggle-switch--xs .private-form__toggle-switch__inner {
-    width: 52px;
-}
-.private-form__toggle-switch--sm .private-form__toggle-switch__inner, .private-form__toggle-switch--xs .private-form__toggle-switch__inner {
-    min-width: 0;
-}
-.private-form__toggle-switch__inner {
-    border-radius: .1875rem;
-    background-color: #eaf0f6;
-    box-shadow: inset 0 0 0 1px #cbd6e2;
-    display: inline-block;
-    height: 2.5rem;
-    min-width: 80px;
-    position: relative;
-    vertical-align: middle;
-    width: auto;
-}
-*, :after, :before {
-    box-sizing: border-box;
-}
+        font-size: 12px;
+        font-size: .75rem;
+    }
 
-.private-checkbox--unlabeled .private-checkbox__text, .private-form__toggle-switch--sm .private-form__toggle-switch__label, .private-form__toggle-switch--xs .private-form__toggle-switch__label, .private-typeahead.hide-search>.private-search-control__wrapper {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    padding: 0;
-    overflow: hidden;
-    clip: rect(0,0,0,0);
-    border: 0;
-}
-.private-form__toggle-switch__label--checked {
-    padding-left: 1rem;
-    padding-right: 3.5rem;
-}
-.private-form__toggle-switch__label {
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-smoothing: antialiased;
-    text-shadow: 0 0 1px transparent;
-    font-family: Avenir Next W02,Helvetica,Arial,sans-serif;
-    font-weight: 600;
-    text-align: center;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    display: block;
-    line-height: 2.5625rem;
-    text-transform: uppercase;
-    visibility: hidden;
-    white-space: nowrap;
-    width: 100%;
-}
-.private-form__toggle-switch--xs .private-form__toggle-switch__handle {
-    width: 26px;
-}
-.private-form__toggle-switch--xs .private-form__toggle-switch__handle, .private-form__toggle-switch--xs .private-form__toggle-switch__inner {
-    height: 26px;
-}
-.private-form__toggle-switch__handle {
-    border-radius: .1875rem;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    transition: all .15s ease-out;
-    background-color: #fff;
-    box-shadow: 0 0 0 0.0625rem #cbd6e2, 0 5px 5px 0 rgba(0,0,0,.08);
-    height: 2.5rem;
-    left: 0;
-    overflow: hidden;
-    padding: .4375rem;
-    position: absolute;
-    top: 0;
-    width: 2.5rem;
-    z-index: 1;
-}
-svg:not(:root) {
-    overflow: hidden;
-}
+    .private-form__label {
+        padding: .5rem .75rem .25rem 0;
+        font-family: Avenir Next W02, Helvetica, Arial, sans-serif;
+        font-weight: 500;
+        font-size: 14px;
+        font-size: .875rem;
+        display: inline-block;
+        vertical-align: middle;
+        color: #fff;
+    }
 
+    .private-form__toggle-switch {
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+        cursor: pointer;
+        display: inline-block;
+        vertical-align: middle;
+    }
 
-.private-checkbox--unlabeled .private-checkbox__text, .private-form__toggle-switch--sm .private-form__toggle-switch__label, .private-form__toggle-switch--xs .private-form__toggle-switch__label, .private-typeahead.hide-search>.private-search-control__wrapper {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    padding: 0;
-    overflow: hidden;
-    clip: rect(0,0,0,0);
-    border: 0;
-}
-.private-form__toggle-switch__label--unchecked {
-    padding-left: 3.5rem;
-    padding-right: 1rem;
-    position: relative;
-    top: -40px;
-    visibility: visible;
-}
-.private-form__toggle-switch--on .private-form__toggle-switch__label--checked,input:checked ~ .private-form__toggle-switch__label--checked
-{
-    color: #fff;
-    visibility: visible;
-}
-.private-form__toggle-switch__label--checked {
-    padding-left: 1rem;
-    padding-right: 3.5rem;
-}
-.private-form__toggle-switch--xs .private-form__toggle-switch--on .private-form__toggle-switch__handle {
-    padding: .3125rem;
-}
+    .sr-only {
+        position: absolute!important;
+        width: 1px!important;
+        height: 1px!important;
+        margin: -1px!important;
+        padding: 0!important;
+        overflow: hidden!important;
+        clip: rect(0, 0, 0, 0)!important;
+        border: 0!important;
+    }
 
-.private-form__toggle-switch__icon {
-    opacity: 0;
-}
-.private-form__toggle-switch--on .private-form__toggle-switch__icon,
-input:checked ~ .private-form__toggle-switch__icon,{
-    opacity: 1;
-}
-.private-form__toggle-switch--on.private-form__toggle-switch__inner {
-    background-color: #00a4bd;
-    box-shadow: none;
-}
-.private-form__toggle-switch--on .private-form__toggle-switch__handle,input:checked ~ .private-form__toggle-switch__handle  {
-    box-shadow: 0 0 0 0.0625rem #00a4bd, 0 5px 5px 0 rgba(0,0,0,.08);
-    left: 100%;
-    transform: translateX(-100%);
-}
-.private-form__toggle-switch--on .private-form__toggle-switch__icon {
-    opacity: 1;
-}
+    .private-form__toggle-switch--sm .private-form__toggle-switch__inner:not(.private-form__toggle-switch--on),
+    .private-form__toggle-switch--xs .private-form__toggle-switch__inner:not(.private-form__toggle-switch--on) {
+        background-color: #f5f8fa;
+    }
+
+    .private-form__toggle-switch--xs .private-form__toggle-switch__handle,
+    .private-form__toggle-switch--xs .private-form__toggle-switch__inner {
+        height: 26px;
+    }
+
+    .private-form__toggle-switch--xs .private-form__toggle-switch__inner {
+        width: 52px;
+    }
+
+    .private-form__toggle-switch--sm .private-form__toggle-switch__inner,
+    .private-form__toggle-switch--xs .private-form__toggle-switch__inner {
+        min-width: 0;
+    }
+
+    .private-form__toggle-switch__inner {
+        border-radius: .1875rem;
+        background-color: #eaf0f6;
+        box-shadow: inset 0 0 0 1px #cbd6e2;
+        display: inline-block;
+        height: 2.5rem;
+        min-width: 80px;
+        position: relative;
+        vertical-align: middle;
+        width: auto;
+    }
+
+    *,
+     :after,
+     :before {
+        box-sizing: border-box;
+    }
+
+    .private-checkbox--unlabeled .private-checkbox__text,
+    .private-form__toggle-switch--sm .private-form__toggle-switch__label,
+    .private-form__toggle-switch--xs .private-form__toggle-switch__label,
+    .private-typeahead.hide-search>.private-search-control__wrapper {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        border: 0;
+    }
+
+    .private-form__toggle-switch__label--checked {
+        padding-left: 1rem;
+        padding-right: 3.5rem;
+    }
+
+    .private-form__toggle-switch__label {
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        font-smoothing: antialiased;
+        text-shadow: 0 0 1px transparent;
+        font-family: Avenir Next W02, Helvetica, Arial, sans-serif;
+        font-weight: 600;
+        text-align: center;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+        display: block;
+        line-height: 2.5625rem;
+        text-transform: uppercase;
+        visibility: hidden;
+        white-space: nowrap;
+        width: 100%;
+    }
+
+    .private-form__toggle-switch--xs .private-form__toggle-switch__handle {
+        width: 26px;
+    }
+
+    .private-form__toggle-switch--xs .private-form__toggle-switch__handle,
+    .private-form__toggle-switch--xs .private-form__toggle-switch__inner {
+        height: 26px;
+    }
+
+    .private-form__toggle-switch__handle {
+        border-radius: .1875rem;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+        transition: all .15s ease-out;
+        background-color: #fff;
+        box-shadow: 0 0 0 0.0625rem #cbd6e2, 0 5px 5px 0 rgba(0, 0, 0, .08);
+        height: 2.5rem;
+        left: 0;
+        overflow: hidden;
+        padding: .4375rem;
+        position: absolute;
+        top: 0;
+        width: 2.5rem;
+        z-index: 1;
+    }
+
+    svg:not(:root) {
+        overflow: hidden;
+    }
 
 
-#status{color:#fff;}
+    .private-checkbox--unlabeled .private-checkbox__text,
+    .private-form__toggle-switch--sm .private-form__toggle-switch__label,
+    .private-form__toggle-switch--xs .private-form__toggle-switch__label,
+    .private-typeahead.hide-search>.private-search-control__wrapper {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        border: 0;
+    }
 
+    .private-form__toggle-switch__label--unchecked {
+        padding-left: 3.5rem;
+        padding-right: 1rem;
+        position: relative;
+        top: -40px;
+        visibility: visible;
+    }
+
+    .private-form__toggle-switch--on .private-form__toggle-switch__label--checked,
+    input:checked~.private-form__toggle-switch__label--checked {
+        color: #fff;
+        visibility: visible;
+    }
+
+    .private-form__toggle-switch__label--checked {
+        padding-left: 1rem;
+        padding-right: 3.5rem;
+    }
+
+    .private-form__toggle-switch--xs .private-form__toggle-switch--on .private-form__toggle-switch__handle {
+        padding: .3125rem;
+    }
+
+    .private-form__toggle-switch__icon {
+        opacity: 0;
+    }
+
+    .private-form__toggle-switch--on .private-form__toggle-switch__icon,
+    input:checked~.private-form__toggle-switch__icon,
+    {
+        opacity: 1;
+    }
+
+    .private-form__toggle-switch--on.private-form__toggle-switch__inner {
+        background-color: #00a4bd;
+        box-shadow: none;
+    }
+
+    .private-form__toggle-switch--on .private-form__toggle-switch__handle,
+    input:checked~.private-form__toggle-switch__handle {
+        box-shadow: 0 0 0 0.0625rem #00a4bd, 0 5px 5px 0 rgba(0, 0, 0, .08);
+        left: 100%;
+        transform: translateX(-100%);
+    }
+
+    .private-form__toggle-switch--on .private-form__toggle-switch__icon {
+        opacity: 1;
+    }
+
+
+    #status {
+        color: #fff;
+    }
     /*To keep CSS organized and easy to understand this css is following this method https://css-tricks.com/combining-the-powers-of-sem-and-bio-for-improving-css/
 Do not let fear of learning a new technique prevent you from contributing, others can help convert your css to fit this flow. so pull request even if it doesn't fit this way of doing things. The important thing is that it works, keeping organized and understandable is second. If everyone finds they hate writing CSS this way we can work out another way to do it.
 */
@@ -210,8 +247,7 @@ Do not let fear of learning a new technique prevent you from contributing, other
     }
 
     .o-menu-grid--design-manager {
-        grid-template-areas: "docs docs"
-                             "darktoggle darktoggle";
+        grid-template-areas: "docs docs" "darktoggle darktoggle";
     }
 
     #hsDebug {
@@ -237,8 +273,9 @@ Do not let fear of learning a new technique prevent you from contributing, other
     #docs {
         grid-area: docs;
     }
-    #dark-toggle{
-      grid-area:darktoggle;
+
+    #dark-toggle {
+        grid-area: darktoggle;
     }
 
 
@@ -419,8 +456,9 @@ Do not let fear of learning a new technique prevent you from contributing, other
     /*state and JS namespaces
 * is-: this indicates the state of the block or element. Most commonly used class is .is-active, like the active link in navigation. */
     /*hide Debug mode button, bust cache button, footer jquery, google page speed, when viewing site backend*/
-    .u-text-orange{
-        color:var(--buttonColor)!important;
+
+    .u-text-orange {
+        color: var(--buttonColor)!important;
     }
 
     body.is-backend .u-hidden-backend {
@@ -439,9 +477,6 @@ Do not let fear of learning a new technique prevent you from contributing, other
         display: none;
     }
     /*js-: this indicates that the specific element is bound to JavaScript events. For example, js-menu-click indicates that the element is bound to the click event. generally JS classes are only added to the html, as they are for targeting with JS not affecting actual styles.*/
-
-
-
     </style>
 </head>
 
@@ -496,42 +531,31 @@ Do not let fear of learning a new technique prevent you from contributing, other
                         </div>
                     </div>
                     <div class="c-toggle-field" id="dark-toggle">
-                     
-
-                    
-                     
-
-
-                      <div class="dark-theme-toggle">
-                        <label class="private-form__label private-form__label--small">
-                          <i18n-string data-locale-at-render="en" data-key="DesignEditorsUI.customWidgetEditor.sidebar.fieldEdit.editorOptions.requiredLabel">
-                            <span class="u-text-orange">DM2</span> - Dark Theme
-                          </i18n-string>
-                          
-                        </label>
-                        <label class="uiToggle private-form__toggle-switch private-form__toggle-switch--xs ">
-                          <input type="checkbox" id="darktheme" class="private-form__toggle-input sr-only">
-                          <span class="uiToggleSwitch private-form__toggle-switch__inner" role="presentation">
+                        <div class="dark-theme-toggle">
+                            <label class="private-form__label private-form__label--small">
+                                <i18n-string data-locale-at-render="en" data-key="DesignEditorsUI.customWidgetEditor.sidebar.fieldEdit.editorOptions.requiredLabel">
+                                    <span class="u-text-orange">DM2</span> - Dark Theme
+                                </i18n-string>
+                            </label>
+                            <label class="uiToggle private-form__toggle-switch private-form__toggle-switch--xs ">
+                                <input type="checkbox" id="darktheme" class="private-form__toggle-input sr-only">
+                                <span class="uiToggleSwitch private-form__toggle-switch__inner" role="presentation">
                             
                             <span class="uiToggleSwitchLabel private-form__toggle-switch__label private-form__toggle-switch__label--checked">
                               on
                             </span>
-                            <span class="private-form__toggle-switch__handle">
+                                <span class="private-form__toggle-switch__handle">
                               <svg role="presentation" viewBox="0 0 15 15.343" xmlns="http://www.w3.org/2000/svg"><title>checkmark</title><path fill="#00a4bd" stroke="#ffffff" stroke-width="2" class="private-form__toggle-switch__icon" d="M1.013 8.11c0-.223.078-.412.234-.568l1.14-1.14c.155-.155.345-.233.568-.233s.413.077.57.233l2.46 2.47 5.492-5.5c.156-.156.346-.234.568-.234.224 0 .413.077.57.233l1.138 1.14c.156.155.234.345.234.568 0 .224-.078.414-.234.57l-6.06 6.06-1.14 1.14c-.155.155-.345.233-.568.233s-.413-.078-.57-.234l-1.138-1.14-3.03-3.03c-.156-.156-.234-.346-.234-.57z"></path></svg>
                               
                             </span>
-                            <span class="uiToggleSwitchLabel private-form__toggle-switch__label private-form__toggle-switch__label--unchecked">
+                                <span class="uiToggleSwitchLabel private-form__toggle-switch__label private-form__toggle-switch__label--unchecked">
                               off
                             </span>
-                            
-                          </span>
-                          
-                        </label>
-                        
-                      </div>
+                                </span>
+                            </label>
+                        </div>
                         <div id="status"></div>
                     </div>
-
                 </div>
             </div>
         </div>

--- a/popup.html
+++ b/popup.html
@@ -1,258 +1,268 @@
-<html>
-
-<head>
-    <title></title>
-    <style>
-    /*To keep CSS organized and easy to understand this css is following this method https://css-tricks.com/combining-the-powers-of-sem-and-bio-for-improving-css/
+<style>
+/*To keep CSS organized and easy to understand this css is following this method https://css-tricks.com/combining-the-powers-of-sem-and-bio-for-improving-css/
 Do not let fear of learning a new technique prevent you from contributing, others can help convert your css to fit this flow. so pull request even if it doesn't fit this way of doing things. The important thing is that it works, keeping organized and understandable is second. If everyone finds they hate writing CSS this way we can work out another way to do it.
 */
-    /*Settings - variables that do not generate visual styles on their own*/
-
-     :root {
-        --buttonColor: #ff7a59;
-    }
-
-     :focus {
-        outline: none;
-    }
-    /*Objects - (namespace: o-) are used for design patterns, such as layouts, where items are being arranged rather than decorated. */
-
-    .o-menu-grid {
-        display: grid;
-        grid-gap: 5px;
-
-        grid-template-columns: 1fr 1fr;
-        grid-template-areas: "debug bustcache" "movejquery amp" "psrequest psrequest" "docs docs";
-    }
-
-    #hsDebug {
-        grid-area: debug;
-    }
-
-    #hsMoveJQueryToFooter {
-        grid-area: movejquery;
-    }
-
-    #hs_amp {
-        grid-area: amp;
-    }
-
-    #bustCache {
-        grid-area: bustcache;
-    }
-
-    #psiScoreRequest {
-        grid-area: psrequest;
-    }
-
-    #docs {
-        grid-area: docs;
-    }
 
 
-    .column_2 {
-        float: left;
-        width: 50%;
-    }
+/*Settings - variables that do not generate visual styles on their own*/
 
-    .row:after {
-        content: "";
-        display: table;
-        clear: both;
-    }
-    /*Elements - HTML native elements default styles without classes*/
+ :root {
+    --buttonColor: #ff7a59;
+}
 
-    * {
-        box-sizing: border-box;
-    }
-
-    body {
-        width: 391px;
-        color: cornflowerblue;
-        background-color: #33475b;
-        background: linear-gradient(45deg, #33475b, #2d3e50);
-        margin: 5px;
-        /*evens context menu spacing to match grid gap*/
-    }
-
-    img {
-        max-width: 100%;
-        height: auto;
-    }
-    /*Components - (namespace: c-) is a small feature that makes up a part of the website/extension. Think buttons, accordions, sliders, modal dialogs, etc. Each component is fully functional by itself and does not rely on any other components. This fact should be considered when you name the component.*/
-
-    .c-btn {
-        padding: 0;
-        height: 44px;
-        display: block;
-        width: 100%;
-        border: 3px solid var(--buttonColor);
-        font-size: 14px;
-        text-align: center;
-        text-decoration: none;
-        overflow: hidden;
-        cursor: pointer;
-        -webkit-appearance: none;
-        background-color: #fff;
-    }
+ :focus {
+    outline: none;
+}
 
 
+/*Objects - (namespace: o-) are used for design patterns, such as layouts, where items are being arranged rather than decorated. */
+
+.o-menu-grid {
+    display: grid;
+    grid-gap: 5px;
+    width: 100%;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas: "debug bustcache" "movejquery amp" "psrequest psrequest" "docs docs";
+}
+
+#hsDebug {
+    grid-area: debug;
+}
+
+#hsMoveJQueryToFooter {
+    grid-area: movejquery;
+}
+
+#hs_amp {
+    grid-area: amp;
+}
+
+#bustCache {
+    grid-area: bustcache;
+}
+
+#psiScoreRequest {
+    grid-area: psrequest;
+}
+
+#docs {
+    grid-area: docs;
+}
 
 
-    .c-btn__face-primary,
-    .c-btn__face-secondary {
-        display: block;
-        padding: 0 22px;
-        line-height: 39px;
-        transition: margin 0.4s;
-    }
+.column_2 {
+    float: left;
+    width: 50%;
+}
 
-    .c-btn__face-primary {
-        background-color: var(--buttonColor);
-        color: #fff;
-    }
-
-    .c-btn__face-secondary {
-        font-size: 13px;
-        padding: 0 0;
-    }
-
-    .c-btn:not(.c-btn--graded):hover .c-btn__face-primary,
-    .c-btn:not(.c-btn--graded):focus .c-btn__face-primary {
-        margin-top: -39px;
-    }
+.row:after {
+    content: "";
+    display: table;
+    clear: both;
+}
 
 
-    .c-btn__psiScore {
-        display: none;
-        text-align: center;
-    }
+/*Elements - HTML native elements default styles without classes*/
 
-    .c-btn__grades {
-        font-size: 33px;
-        padding: 16px;
-        color: #e43;
-    }
+* {
+    box-sizing: border-box;
+}
 
-    .c-btn__score {
-        /*update js*/
-        font-size: 40px;
-        display: block;
-        font-weight: bold;
-    }
-    /*Scopes - The purpose of the scope (namespace: s-) is to give us the highest specificity so we can overwrite any styles for a specific purpose.
+body {
+    width: 391px;
+    color: cornflowerblue;
+    background-color: #33475b;
+    background: linear-gradient(45deg, #33475b, #2d3e50);
+    margin: 5px;
+    /*evens context menu spacing to match grid gap*/
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+}
+
+
+/*Components - (namespace: c-) is a small feature that makes up a part of the website/extension. Think buttons, accordions, sliders, modal dialogs, etc. Each component is fully functional by itself and does not rely on any other components. This fact should be considered when you name the component.*/
+
+.c-btn {
+    padding: 0;
+    height: 44px;
+    display: block;
+    width: 100%;
+    border: 3px solid var(--buttonColor);
+    font-size: 14px;
+    text-align: center;
+    text-decoration: none;
+    overflow: hidden;
+    cursor: pointer;
+    -webkit-appearance: none;
+    background-color: #fff;
+}
+
+
+
+
+.c-btn__face-primary,
+.c-btn__face-secondary {
+    display: block;
+    padding: 0 22px;
+    line-height: 39px;
+    transition: margin 0.4s;
+}
+
+.c-btn__face-primary {
+    background-color: var(--buttonColor);
+    color: #fff;
+}
+
+.c-btn__face-secondary {
+    font-size: 13px;
+    padding: 0 0;
+}
+
+.c-btn:not(.c-btn--graded):hover .c-btn__face-primary,
+.c-btn:not(.c-btn--graded):focus .c-btn__face-primary {
+    margin-top: -39px;
+}
+
+
+.c-btn__psiScore {
+    display: none;
+    text-align: center;
+}
+
+.c-btn__grades {
+    font-size: 33px;
+    padding: 16px;
+    color: #e43;
+}
+
+.c-btn__score {
+    /*update js*/
+    font-size: 40px;
+    display: block;
+    font-weight: bold;
+}
+
+
+/*Scopes - The purpose of the scope (namespace: s-) is to give us the highest specificity so we can overwrite any styles for a specific purpose.
 
 */
 
-    .c-btn--graded {
-        /*update js to update the class it adds*/
-        overflow: initial;
-        height: initial;
-        /*background-image: url(https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/pagespeed-logo.png);*/
-        background-size: contain;
-        background-position: center bottom;
-        background-repeat: no-repeat;
-        background-size: 150px;
-    }
+.c-tab-slider {
+    width: 100vw;
+}
 
-    .c-btn--graded .c-btn__face-secondary {
-        display: none;
-    }
+.c-btn--graded {
+    /*update js to update the class it adds*/
+    overflow: initial;
+    height: initial;
+    /*background-image: url(https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/pagespeed-logo.png);*/
+    background-size: contain;
+    background-position: center bottom;
+    background-repeat: no-repeat;
+    background-size: 150px;
+}
 
-    .c-btn--docs {
-        cursor: unset;
-    }
+.c-btn--graded .c-btn__face-secondary {
+    display: none;
+}
 
-    .c-btn--docs .c-btn__face-secondary {
-        display: flex;
-        align-items: center;
-        justify-content: space-around;
-    }
+.c-btn--docs {
+    cursor: unset;
+}
 
-    .c-btn--docs a {
-        padding: 0 10px;
-    }
+.c-btn--docs .c-btn__face-secondary {
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+}
 
-    .c-btn--docs a:hover,
-    .c-btn--docs a:focus {
-        color: var(--buttonColor);
-    }
-    /*Utility - Sometimes you may want to make changes only for a certain style in a specific place. In that case, utility (namespace: u-) classes can help us update it without changing the whole CSS structure.*/
-    /*state and JS namespaces
+.c-btn--docs a {
+    padding: 0 10px;
+}
+
+.c-btn--docs a:hover,
+.c-btn--docs a:focus {
+    color: var(--buttonColor);
+}
+
+
+/*Utility - Sometimes you may want to make changes only for a certain style in a specific place. In that case, utility (namespace: u-) classes can help us update it without changing the whole CSS structure.*/
+
+
+/*state and JS namespaces
 * is-: this indicates the state of the block or element. Most commonly used class is .is-active, like the active link in navigation. */
-    /*hide Debug mode button, bust cache button, footer jquery, google page speed, when viewing site backend*/
 
-    body.is-backend .u-hidden-backend {
-        display: none;
-    }
 
-    body.is-dm1 .u-hidden-dm1 {
-        display: none;
-    }
+/*hide Debug mode button, bust cache button, footer jquery, google page speed, when viewing site backend*/
 
-    body.is-dm2 .u-hidden-dm2 {
-        display: none;
-    }
+body.is-backend .u-hidden-backend {
+    display: none;
+}
 
-    body.is-hs-docs .u-hidden-hs-docs {
-        display: none;
-    }
-    /*js-: this indicates that the specific element is bound to JavaScript events. For example, js-menu-click indicates that the element is bound to the click event. generally JS classes are only added to the html, as they are for targeting with JS not affecting actual styles.*/
-    </style>
-</head>
+body.is-dm1 .u-hidden-dm1 {
+    display: none;
+}
 
-<body>
-    <div class="c-tab-slider">
-        <div class="c-tab-slider__tab" id="debug-tools">
-            <!--This tab will be focused when the user is not in the design manager -->
-            <div class="o-menu-grid">
-                <div class="o-menu-grid">
-                    <button class="c-btn face-button js-click--debug" id="hsDebug">
-                        <div class="c-btn__face-primary">Debug Mode</div>
-                        <div class="c-btn__face-secondary">hsDebug=True</div>
-                    </button>
-                    <button class="c-btn face-button js-click--bust-cache" id="cacheBuster">
-                        <div class="c-btn__face-primary">Bust Cache</div>
-                        <div class="c-btn__face-secondary">bustCache=[random Number]</div>
-                    </button>
-                    <button class="c-btn face-button js-click--move-jquery-to-footer" id="hsMoveJQueryToFooter">
-                        <div class="c-btn__face-primary">Footer jQuery</div>
-                        <div class="c-btn__face-secondary">hsMoveJQueryToFooter=True</div>
-                    </button>
-                    <button class="c-btn face-button js-click--amp" id="hs_amp">
-                        <div class="c-btn__face-primary">Amp</div>
-                        <div class="c-btn__face-secondary">hs_amp=true</div>
-                    </button>
-                    <button class="c-btn face-button js-click--psi-score-request" id="psiScoreRequest">
-                        <div class="c-btn__face-primary">Google Page Speed Insights Scores</div>
-                        <div class="c-btn__face-secondary">Score Me!
-                            <!--<img style="height: 39px;" src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/pagespeed.png">--></div>
-                        <div class="row c-btn__grades">
-                            <div class="c-btn__psiScore column_2" id="desktop_psi_placeholder">grading desktop...
-                                <!--<img src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/NewCorgiDance.gif">--></div>
-                            <div class="c-btn__psiScore column_2" id="mobile_psi_placeholder">grading mobile...
-                                <!--<img src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/NewCorgiDance.gif">--></div>
-                        </div>
-                    </button>
+body.is-dm2 .u-hidden-dm2 {
+    display: none;
+}
+
+body.is-hs-docs .u-hidden-hs-docs {
+    display: none;
+}
+
+
+/*js-: this indicates that the specific element is bound to JavaScript events. For example, js-menu-click indicates that the element is bound to the click event. generally JS classes are only added to the html, as they are for targeting with JS not affecting actual styles.*/
+</style>
+<div class="c-tab-slider">
+    <div class="c-tab-slider__tab" id="debug-tools">
+        <!--This tab will be focused when the user is not in the design manager -->
+        <div class="o-menu-grid">
+            <button class="c-btn face-button js-click--debug" id="hsDebug">
+                <div class="c-btn__face-primary">Debug Mode</div>
+                <div class="c-btn__face-secondary">hsDebug=True</div>
+            </button>
+            <button class="c-btn face-button js-click--bust-cache" id="cacheBuster">
+                <div class="c-btn__face-primary">Bust Cache</div>
+                <div class="c-btn__face-secondary">bustCache=[random Number]</div>
+            </button>
+            <button class="c-btn face-button js-click--move-jquery-to-footer" id="hsMoveJQueryToFooter">
+                <div class="c-btn__face-primary">Footer jQuery</div>
+                <div class="c-btn__face-secondary">hsMoveJQueryToFooter=True</div>
+            </button>
+            <button class="c-btn face-button js-click--amp" id="hs_amp">
+                <div class="c-btn__face-primary">Amp</div>
+                <div class="c-btn__face-secondary">hs_amp=true</div>
+            </button>
+            <button class="c-btn face-button js-click--psi-score-request" id="psiScoreRequest">
+                <div class="c-btn__face-primary">Google Page Speed Insights Scores</div>
+                <div class="c-btn__face-secondary">Score Me!
+                    <!--<img style="height: 39px;" src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/pagespeed.png">--></div>
+                <div class="row c-btn__grades">
+                    <div class="c-btn__psiScore column_2" id="desktop_psi_placeholder">grading desktop...
+                        <!--<img src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/NewCorgiDance.gif">--></div>
+                    <div class="c-btn__psiScore column_2" id="mobile_psi_placeholder">grading mobile...
+                        <!--<img src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/NewCorgiDance.gif">--></div>
                 </div>
-            </div>
+            </button>
         </div>
-        <div class="c-tab-slider__tab" id="design-manager">
-            <!-- this tab will be focused while the user is in the design manager any features intended only for DM1 or DM2 should get disabled if they do not work in the current version of the design manager -->
-            <div class="c-btn c-btn--docs face-button" id="docs">
-                <div class="c-btn__face-primary">Documentation</div>
-                <div class="c-btn__face-secondary">
-                    <a target="blank" href="https://designers.hubspot.com/en/docs/hubl/hubl-supported-functions">Functions<!--add opens in new window icon--></a>
-                    <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-variables">Variables<!--add opens in new window icon--></a> <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-filters">Filters<!--add opens in new window icon--></a>
-                    <a target="blank" href=" https://designers.hubspot.com/docs/tools/hubdb">HubDB<!--add opens in new window icon--></a>
-                </div>
+    </div>
+    <div class="c-tab-slider__tab" id="design-manager">
+        <!-- this tab will be focused while the user is in the design manager any features intended only for DM1 or DM2 should get disabled if they do not work in the current version of the design manager -->
+        <div class="c-btn c-btn--docs face-button" id="docs">
+            <div class="c-btn__face-primary">Documentation</div>
+            <div class="c-btn__face-secondary">
+                <a target="blank" href="https://designers.hubspot.com/en/docs/hubl/hubl-supported-functions">Functions<!--add opens in new window icon--></a>
+                <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-variables">Variables<!--add opens in new window icon--></a> <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-filters">Filters<!--add opens in new window icon--></a>
+                <a target="blank" href=" https://designers.hubspot.com/docs/tools/hubdb">HubDB<!--add opens in new window icon--></a>
             </div>
         </div>
     </div>
-    <!--  <button id="psiScoreRequest" class="debugButton">Grade my page</button>
+</div>
+<!--  <button id="psiScoreRequest" class="debugButton">Grade my page</button>
  -->
-    <script src="jquery-3.2.1.min.js"></script>
-    <script src="popup.js"></script>
-</body>
-
-</html>
+<script src="jquery-3.2.1.min.js"></script>
+<script src="popup.js"></script>

--- a/popup.html
+++ b/popup.html
@@ -3,6 +3,177 @@
 <head>
     <title></title>
     <style>
+
+
+    /*checkbox input stolen from HS, we really should switch this to be a normal css checkbox, the html and css is over the top*/
+    .private-form__label--small {
+    font-size: 12px;
+    font-size: .75rem;
+}
+.private-form__label {
+    padding: .5rem .75rem .25rem 0;
+    font-family: Avenir Next W02,Helvetica,Arial,sans-serif;
+    font-weight: 500;
+    font-size: 14px;
+    font-size: .875rem;
+    display: inline-block;
+    vertical-align: middle;
+}
+.private-form__toggle-switch {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    cursor: pointer;
+    display: inline-block;
+    vertical-align: middle;
+}
+.sr-only {
+    position: absolute!important;
+    width: 1px!important;
+    height: 1px!important;
+    margin: -1px!important;
+    padding: 0!important;
+    overflow: hidden!important;
+    clip: rect(0,0,0,0)!important;
+    border: 0!important;
+}
+.private-form__toggle-switch--sm .private-form__toggle-switch__inner:not(.private-form__toggle-switch--on), .private-form__toggle-switch--xs .private-form__toggle-switch__inner:not(.private-form__toggle-switch--on) {
+    background-color: #f5f8fa;
+}
+.private-form__toggle-switch--xs .private-form__toggle-switch__handle, .private-form__toggle-switch--xs .private-form__toggle-switch__inner {
+    height: 26px;
+}
+.private-form__toggle-switch--xs .private-form__toggle-switch__inner {
+    width: 52px;
+}
+.private-form__toggle-switch--sm .private-form__toggle-switch__inner, .private-form__toggle-switch--xs .private-form__toggle-switch__inner {
+    min-width: 0;
+}
+.private-form__toggle-switch__inner {
+    border-radius: .1875rem;
+    background-color: #eaf0f6;
+    box-shadow: inset 0 0 0 1px #cbd6e2;
+    display: inline-block;
+    height: 2.5rem;
+    min-width: 80px;
+    position: relative;
+    vertical-align: middle;
+    width: auto;
+}
+*, :after, :before {
+    box-sizing: border-box;
+}
+
+.private-checkbox--unlabeled .private-checkbox__text, .private-form__toggle-switch--sm .private-form__toggle-switch__label, .private-form__toggle-switch--xs .private-form__toggle-switch__label, .private-typeahead.hide-search>.private-search-control__wrapper {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+    border: 0;
+}
+.private-form__toggle-switch__label--checked {
+    padding-left: 1rem;
+    padding-right: 3.5rem;
+}
+.private-form__toggle-switch__label {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-smoothing: antialiased;
+    text-shadow: 0 0 1px transparent;
+    font-family: Avenir Next W02,Helvetica,Arial,sans-serif;
+    font-weight: 600;
+    text-align: center;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    display: block;
+    line-height: 2.5625rem;
+    text-transform: uppercase;
+    visibility: hidden;
+    white-space: nowrap;
+    width: 100%;
+}
+.private-form__toggle-switch--xs .private-form__toggle-switch__handle {
+    width: 26px;
+}
+.private-form__toggle-switch--xs .private-form__toggle-switch__handle, .private-form__toggle-switch--xs .private-form__toggle-switch__inner {
+    height: 26px;
+}
+.private-form__toggle-switch__handle {
+    border-radius: .1875rem;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    transition: all .15s ease-out;
+    background-color: #fff;
+    box-shadow: 0 0 0 0.0625rem #cbd6e2, 0 5px 5px 0 rgba(0,0,0,.08);
+    height: 2.5rem;
+    left: 0;
+    overflow: hidden;
+    padding: .4375rem;
+    position: absolute;
+    top: 0;
+    width: 2.5rem;
+    z-index: 1;
+}
+svg:not(:root) {
+    overflow: hidden;
+}
+
+
+.private-checkbox--unlabeled .private-checkbox__text, .private-form__toggle-switch--sm .private-form__toggle-switch__label, .private-form__toggle-switch--xs .private-form__toggle-switch__label, .private-typeahead.hide-search>.private-search-control__wrapper {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+    border: 0;
+}
+.private-form__toggle-switch__label--unchecked {
+    padding-left: 3.5rem;
+    padding-right: 1rem;
+    position: relative;
+    top: -40px;
+    visibility: visible;
+}
+.private-form__toggle-switch--on .private-form__toggle-switch__label--checked,input:checked ~ .private-form__toggle-switch__label--checked
+{
+    color: #fff;
+    visibility: visible;
+}
+.private-form__toggle-switch__label--checked {
+    padding-left: 1rem;
+    padding-right: 3.5rem;
+}
+.private-form__toggle-switch--xs .private-form__toggle-switch--on .private-form__toggle-switch__handle {
+    padding: .3125rem;
+}
+
+.private-form__toggle-switch__icon {
+    opacity: 0;
+}
+.private-form__toggle-switch--on .private-form__toggle-switch__icon,
+input:checked ~ .private-form__toggle-switch__icon,{
+    opacity: 1;
+}
+.private-form__toggle-switch--on.private-form__toggle-switch__inner {
+    background-color: #00a4bd;
+    box-shadow: none;
+}
+.private-form__toggle-switch--on .private-form__toggle-switch__handle,input:checked ~ .private-form__toggle-switch__handle  {
+    box-shadow: 0 0 0 0.0625rem #00a4bd, 0 5px 5px 0 rgba(0,0,0,.08);
+    left: 100%;
+    transform: translateX(-100%);
+}
+
     /*To keep CSS organized and easy to understand this css is following this method https://css-tricks.com/combining-the-powers-of-sem-and-bio-for-improving-css/
 Do not let fear of learning a new technique prevent you from contributing, others can help convert your css to fit this flow. so pull request even if it doesn't fit this way of doing things. The important thing is that it works, keeping organized and understandable is second. If everyone finds they hate writing CSS this way we can work out another way to do it.
 */
@@ -254,6 +425,9 @@ Do not let fear of learning a new technique prevent you from contributing, other
         display: none;
     }
     /*js-: this indicates that the specific element is bound to JavaScript events. For example, js-menu-click indicates that the element is bound to the click event. generally JS classes are only added to the html, as they are for targeting with JS not affecting actual styles.*/
+
+
+
     </style>
 </head>
 
@@ -315,6 +489,35 @@ Do not let fear of learning a new technique prevent you from contributing, other
 
                       <div id="status"></div>
                       <button id="save">Save</button>
+
+
+                      <div class="dark-theme-toggle">
+                        <label class="private-form__label private-form__label--small">
+                          <i18n-string data-locale-at-render="en" data-key="DesignEditorsUI.customWidgetEditor.sidebar.fieldEdit.editorOptions.requiredLabel">
+                            Dark Theme
+                          </i18n-string>
+                          
+                        </label>
+                        <label class="uiToggle private-form__toggle-switch private-form__toggle-switch--xs ">
+                          <input type="checkbox" id="darktheme" class="private-form__toggle-input sr-only">
+                          <span class="uiToggleSwitch private-form__toggle-switch__inner" role="presentation">
+                            
+                            <span class="uiToggleSwitchLabel private-form__toggle-switch__label private-form__toggle-switch__label--checked">
+                              on
+                            </span>
+                            <span class="private-form__toggle-switch__handle">
+                              <svg role="presentation" viewBox="0 0 15 15.343" xmlns="http://www.w3.org/2000/svg"><title>checkmark</title><path fill="#00a4bd" stroke="#ffffff" stroke-width="2" class="private-form__toggle-switch__icon" d="M1.013 8.11c0-.223.078-.412.234-.568l1.14-1.14c.155-.155.345-.233.568-.233s.413.077.57.233l2.46 2.47 5.492-5.5c.156-.156.346-.234.568-.234.224 0 .413.077.57.233l1.138 1.14c.156.155.234.345.234.568 0 .224-.078.414-.234.57l-6.06 6.06-1.14 1.14c-.155.155-.345.233-.568.233s-.413-.078-.57-.234l-1.138-1.14-3.03-3.03c-.156-.156-.234-.346-.234-.57z"></path></svg>
+                              
+                            </span>
+                            <span class="uiToggleSwitchLabel private-form__toggle-switch__label private-form__toggle-switch__label--unchecked">
+                              off
+                            </span>
+                            
+                          </span>
+                          
+                        </label>
+                        
+                      </div>
                     </div>
 
                 </div>

--- a/popup.html
+++ b/popup.html
@@ -93,6 +93,20 @@ Do not let fear of learning a new technique prevent you from contributing, other
         width: 100vw;
     }
 
+
+    .c-tab-slider__tab-selector {
+        -webkit-appearance: none;
+        border: 0;
+        display: block;
+        width: 50%;
+        font-size: 13px;
+        text-transform: uppercase;
+        font-weight: bold;
+    }
+
+    .c-tab-slider__controls {
+        display: flex;
+    }
     .c-tab-slider__tab {
         display: block;
         width: 100vw;
@@ -105,10 +119,10 @@ Do not let fear of learning a new technique prevent you from contributing, other
         flex-flow: row;
         position:relative;
     }
-    .c-tab-slider--state-design-manager{
+    .c-tab-slider--state-design-manager .c-tab-slider__track{
         left:-100vw;
     }
-    .c-tab-slider--state-debug{
+    .c-tab-slider--state-debug  .c-tab-slider__track{
         left:0;
     }
 
@@ -234,6 +248,10 @@ Do not let fear of learning a new technique prevent you from contributing, other
 
 <body>
     <div class="c-tab-slider">
+      <div class="c-tab-slider__controls">
+        <button class="c-tab-slider__tab-selector js-click--tab-debug">Debug</button>
+        <button class="c-tab-slider__tab-selector js-click--tab-develop">Develop</button>
+      </div>
         <div class="c-tab-slider__track c-tab-slider--state-debug">
             <div class="c-tab-slider__tab" id="debug-tools">
                 <!--This tab will be focused when the user is not in the design manager -->

--- a/popup.html
+++ b/popup.html
@@ -203,7 +203,8 @@ Do not let fear of learning a new technique prevent you from contributing, other
     }
 
     .o-menu-grid--design-manager {
-        grid-template-areas: "docs docs";
+        grid-template-areas: "docs docs"
+                             "darktoggle darktoggle";
     }
 
     #hsDebug {
@@ -228,6 +229,9 @@ Do not let fear of learning a new technique prevent you from contributing, other
 
     #docs {
         grid-area: docs;
+    }
+    #dark-toggle{
+      grid-area:darktoggle;
     }
 
 
@@ -481,14 +485,11 @@ Do not let fear of learning a new technique prevent you from contributing, other
                             <a target="blank" href=" https://designers.hubspot.com/docs/tools/hubdb">HubDB<!--add opens in new window icon--></a>
                         </div>
                     </div>
-                    <div class="setting-wrapper">
-                      <label>
-                        <input type="checkbox" id="darktheme">
-                        Activate dark theme in the new IDE
-                      </label>
+                    <div class="c-toggle-field" id="dark-toggle">
+                     
 
-                      <div id="status"></div>
-                      <button id="save">Save</button>
+                    
+                     
 
 
                       <div class="dark-theme-toggle">
@@ -518,6 +519,7 @@ Do not let fear of learning a new technique prevent you from contributing, other
                         </label>
                         
                       </div>
+                        <div id="status"></div>
                     </div>
 
                 </div>

--- a/popup.html
+++ b/popup.html
@@ -157,30 +157,52 @@ img {
 /*Utility - Sometimes you may want to make changes only for a certain style in a specific place. In that case, utility (namespace: u-) classes can help us update it without changing the whole CSS structure.*/
 
 /*state and JS namespaces
-* is-: this indicates the state of the block or element. Most commonly used class is .is-active, like the active link in navigation.
+* is-: this indicates the state of the block or element. Most commonly used class is .is-active, like the active link in navigation. */
 
-*js-: this indicates that the specific element is bound to JavaScript events. For example, js-menu-click indicates that the element is bound to the click event. generally JS classes are only added to the html, as they are for targeting with JS not affecting actual styles.*/
+/*hide Debug mode button, bust cache button, footer jquery, google page speed, when viewing site backend*/
+body.is-backend .u-hidden-backend{
+  display:none;
+}
+
+body.is-dm1 .u-hidden-dm1{
+  display:none;
+}
+
+body.is-dm2 .u-hidden-dm2{
+  display:none;
+}
+body.is-hs-docs .u-hidden-hs-docs{
+  display:none;
+}
+body.is-backend .o-menu-grid {
+  grid-template-columns: 1fr 1fr;
+  grid-template-areas:
+    "docs docs";
+}
+
+
+/*js-: this indicates that the specific element is bound to JavaScript events. For example, js-menu-click indicates that the element is bound to the click event. generally JS classes are only added to the html, as they are for targeting with JS not affecting actual styles.*/
 	</style>
 </head>
 <body>
 	<div class="o-menu-grid">
   
-      <button class="c-btn face-button js-click--debug" id="hsDebug">
+      <button class="c-btn face-button js-click--debug u-hidden-backend" id="hsDebug">
         <div class="c-btn__face-primary">Debug Mode</div>
         <div class="c-btn__face-secondary">hsDebug=True</div>
       </button>
-      <button class="c-btn face-button js-click--bust-cache" id="cacheBuster">
+      <button class="c-btn face-button js-click--bust-cache u-hidden-backend" id="cacheBuster">
         <div class="c-btn__face-primary">Bust Cache</div>
         <div class="c-btn__face-secondary">bustCache=[random Number]</div>
       </button>
-      <button class="c-btn face-button js-click--move-jquery-to-footer" id="hsMoveJQueryToFooter">
+      <button class="c-btn face-button js-click--move-jquery-to-footer u-hidden-backend" id="hsMoveJQueryToFooter">
         <div class="c-btn__face-primary">Footer jQuery</div>
         <div class="c-btn__face-secondary">hsMoveJQueryToFooter=True</div>
       </button>
     
 
 
-    <button class="c-btn face-button js-click--psi-score-request" id="psiScoreRequest">
+    <button class="c-btn face-button js-click--psi-score-request u-hidden-backend" id="psiScoreRequest">
       <div class="c-btn__face-primary">Google Page Speed Insights Scores</div>
       <div class="c-btn__face-secondary">Score Me!<!--<img style="height: 39px;" src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/pagespeed.png">--></div>
       <div class="row c-btn__grades">

--- a/popup.html
+++ b/popup.html
@@ -102,6 +102,7 @@ Do not let fear of learning a new technique prevent you from contributing, other
         font-size: 13px;
         text-transform: uppercase;
         font-weight: bold;
+        border-bottom:5px transparent solid;
     }
 
     .c-tab-slider__controls {
@@ -118,9 +119,14 @@ Do not let fear of learning a new technique prevent you from contributing, other
         display: flex;
         flex-flow: row;
         position:relative;
+        -webkit-transition: all 600ms cubic-bezier(0.77, 0, 0.175, 1);
+        transition:         all 600ms cubic-bezier(0.77, 0, 0.175, 1);
     }
     .c-tab-slider--state-design-manager .c-tab-slider__track{
         left:-100vw;
+    }
+    .c-tab-slider--state-design-manager .c-tab-slider__tab-selector--develop,.c-tab-slider--state-debug .c-tab-slider__tab-selector--debug{
+      border-bottom-color:var(--buttonColor);
     }
     .c-tab-slider--state-debug  .c-tab-slider__track{
         left:0;
@@ -249,8 +255,8 @@ Do not let fear of learning a new technique prevent you from contributing, other
 <body>
     <div class="c-tab-slider">
       <div class="c-tab-slider__controls">
-        <button class="c-tab-slider__tab-selector js-click--tab-debug">Debug</button>
-        <button class="c-tab-slider__tab-selector js-click--tab-develop">Develop</button>
+        <button class="c-tab-slider__tab-selector js-click--tab-debug c-tab-slider__tab-selector--debug">Debug</button>
+        <button class="c-tab-slider__tab-selector c-tab-slider__tab-selector--develop js-click--tab-develop">Develop</button>
       </div>
         <div class="c-tab-slider__track c-tab-slider--state-debug">
             <div class="c-tab-slider__tab" id="debug-tools">

--- a/popup.html
+++ b/popup.html
@@ -21,8 +21,16 @@ Do not let fear of learning a new technique prevent you from contributing, other
         display: grid;
         grid-gap: 5px;
         width: 100%;
+        width: calc(100vw - 10px);
         grid-template-columns: 1fr 1fr;
-        grid-template-areas: "debug bustcache" "movejquery amp" "psrequest psrequest" "docs docs";
+        grid-template-areas: "debug bustcache" "movejquery amp" "psrequest psrequest";
+        /*margin-right: 5px;*/
+    }
+    .o-menu-grid--debug{
+        grid-template-areas: "debug bustcache" "movejquery amp" "psrequest psrequest";
+    }
+    .o-menu-grid--design-manager{
+        grid-template-areas: "docs docs";
     }
 
     #hsDebug {
@@ -71,8 +79,8 @@ Do not let fear of learning a new technique prevent you from contributing, other
         color: cornflowerblue;
         background-color: #33475b;
         background: linear-gradient(45deg, #33475b, #2d3e50);
-        margin: 5px;
-        /*evens context menu spacing to match grid gap*/
+        margin:0;
+        
     }
 
     img {
@@ -80,6 +88,29 @@ Do not let fear of learning a new technique prevent you from contributing, other
         height: auto;
     }
     /*Components - (namespace: c-) is a small feature that makes up a part of the website/extension. Think buttons, accordions, sliders, modal dialogs, etc. Each component is fully functional by itself and does not rely on any other components. This fact should be considered when you name the component.*/
+
+    .c-tab-slider {
+        width: 100vw;
+    }
+
+    .c-tab-slider__tab {
+        display: block;
+        width: 100vw;
+        padding:5px;
+
+    }
+
+    .c-tab-slider__track {
+        display: flex;
+        flex-flow: row;
+        position:relative;
+    }
+    .c-tab-slider--state-design-manager{
+        left:-100vw;
+    }
+    .c-tab-slider--state-debug{
+        left:0;
+    }
 
     .c-btn {
         padding: 0;
@@ -144,10 +175,6 @@ Do not let fear of learning a new technique prevent you from contributing, other
 
 */
 
-    .c-tab-slider {
-        width: 100vw;
-    }
-
     .c-btn--graded {
         /*update js to update the class it adds*/
         overflow: initial;
@@ -207,10 +234,10 @@ Do not let fear of learning a new technique prevent you from contributing, other
 
 <body>
     <div class="c-tab-slider">
-        <div class="c-tab-slider__track">
+        <div class="c-tab-slider__track c-tab-slider--state-debug">
             <div class="c-tab-slider__tab" id="debug-tools">
                 <!--This tab will be focused when the user is not in the design manager -->
-                <div class="o-menu-grid">
+                <div class="o-menu-grid o-menu-grid--debug">
                     <button class="c-btn face-button js-click--debug" id="hsDebug">
                         <div class="c-btn__face-primary">Debug Mode</div>
                         <div class="c-btn__face-secondary">hsDebug=True</div>

--- a/popup.html
+++ b/popup.html
@@ -207,46 +207,48 @@ Do not let fear of learning a new technique prevent you from contributing, other
 
 <body>
     <div class="c-tab-slider">
-        <div class="c-tab-slider__tab" id="debug-tools">
-            <!--This tab will be focused when the user is not in the design manager -->
-            <div class="o-menu-grid">
-                <button class="c-btn face-button js-click--debug" id="hsDebug">
-                    <div class="c-btn__face-primary">Debug Mode</div>
-                    <div class="c-btn__face-secondary">hsDebug=True</div>
-                </button>
-                <button class="c-btn face-button js-click--bust-cache" id="cacheBuster">
-                    <div class="c-btn__face-primary">Bust Cache</div>
-                    <div class="c-btn__face-secondary">bustCache=[random Number]</div>
-                </button>
-                <button class="c-btn face-button js-click--move-jquery-to-footer" id="hsMoveJQueryToFooter">
-                    <div class="c-btn__face-primary">Footer jQuery</div>
-                    <div class="c-btn__face-secondary">hsMoveJQueryToFooter=True</div>
-                </button>
-                <button class="c-btn face-button js-click--amp" id="hs_amp">
-                    <div class="c-btn__face-primary">Amp</div>
-                    <div class="c-btn__face-secondary">hs_amp=true</div>
-                </button>
-                <button class="c-btn face-button js-click--psi-score-request" id="psiScoreRequest">
-                    <div class="c-btn__face-primary">Google Page Speed Insights Scores</div>
-                    <div class="c-btn__face-secondary">Score Me!
-                        <!--<img style="height: 39px;" src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/pagespeed.png">--></div>
-                    <div class="row c-btn__grades">
-                        <div class="c-btn__psiScore column_2" id="desktop_psi_placeholder">grading desktop...
-                            <!--<img src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/NewCorgiDance.gif">--></div>
-                        <div class="c-btn__psiScore column_2" id="mobile_psi_placeholder">grading mobile...
-                            <!--<img src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/NewCorgiDance.gif">--></div>
-                    </div>
-                </button>
+        <div class="c-tab-slider__track">
+            <div class="c-tab-slider__tab" id="debug-tools">
+                <!--This tab will be focused when the user is not in the design manager -->
+                <div class="o-menu-grid">
+                    <button class="c-btn face-button js-click--debug" id="hsDebug">
+                        <div class="c-btn__face-primary">Debug Mode</div>
+                        <div class="c-btn__face-secondary">hsDebug=True</div>
+                    </button>
+                    <button class="c-btn face-button js-click--bust-cache" id="cacheBuster">
+                        <div class="c-btn__face-primary">Bust Cache</div>
+                        <div class="c-btn__face-secondary">bustCache=[random Number]</div>
+                    </button>
+                    <button class="c-btn face-button js-click--move-jquery-to-footer" id="hsMoveJQueryToFooter">
+                        <div class="c-btn__face-primary">Footer jQuery</div>
+                        <div class="c-btn__face-secondary">hsMoveJQueryToFooter=True</div>
+                    </button>
+                    <button class="c-btn face-button js-click--amp" id="hs_amp">
+                        <div class="c-btn__face-primary">Amp</div>
+                        <div class="c-btn__face-secondary">hs_amp=true</div>
+                    </button>
+                    <button class="c-btn face-button js-click--psi-score-request" id="psiScoreRequest">
+                        <div class="c-btn__face-primary">Google Page Speed Insights Scores</div>
+                        <div class="c-btn__face-secondary">Score Me!
+                            <!--<img style="height: 39px;" src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/pagespeed.png">--></div>
+                        <div class="row c-btn__grades">
+                            <div class="c-btn__psiScore column_2" id="desktop_psi_placeholder">grading desktop...
+                                <!--<img src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/NewCorgiDance.gif">--></div>
+                            <div class="c-btn__psiScore column_2" id="mobile_psi_placeholder">grading mobile...
+                                <!--<img src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/NewCorgiDance.gif">--></div>
+                        </div>
+                    </button>
+                </div>
             </div>
-        </div>
-        <div class="c-tab-slider__tab" id="design-manager">
-            <!-- this tab will be focused while the user is in the design manager any features intended only for DM1 or DM2 should get disabled if they do not work in the current version of the design manager -->
-            <div class="c-btn c-btn--docs face-button" id="docs">
-                <div class="c-btn__face-primary">Documentation</div>
-                <div class="c-btn__face-secondary">
-                    <a target="blank" href="https://designers.hubspot.com/en/docs/hubl/hubl-supported-functions">Functions<!--add opens in new window icon--></a>
-                    <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-variables">Variables<!--add opens in new window icon--></a> <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-filters">Filters<!--add opens in new window icon--></a>
-                    <a target="blank" href=" https://designers.hubspot.com/docs/tools/hubdb">HubDB<!--add opens in new window icon--></a>
+            <div class="c-tab-slider__tab" id="design-manager">
+                <!-- this tab will be focused while the user is in the design manager any features intended only for DM1 or DM2 should get disabled if they do not work in the current version of the design manager -->
+                <div class="c-btn c-btn--docs face-button" id="docs">
+                    <div class="c-btn__face-primary">Documentation</div>
+                    <div class="c-btn__face-secondary">
+                        <a target="blank" href="https://designers.hubspot.com/en/docs/hubl/hubl-supported-functions">Functions<!--add opens in new window icon--></a>
+                        <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-variables">Variables<!--add opens in new window icon--></a> <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-filters">Filters<!--add opens in new window icon--></a>
+                        <a target="blank" href=" https://designers.hubspot.com/docs/tools/hubdb">HubDB<!--add opens in new window icon--></a>
+                    </div>
                 </div>
             </div>
         </div>

--- a/popup.html
+++ b/popup.html
@@ -174,6 +174,10 @@ input:checked ~ .private-form__toggle-switch__icon,{
     left: 100%;
     transform: translateX(-100%);
 }
+.private-form__toggle-switch--on .private-form__toggle-switch__icon {
+    opacity: 1;
+}
+
 
 #status{color:#fff;}
 

--- a/popup.html
+++ b/popup.html
@@ -419,6 +419,9 @@ Do not let fear of learning a new technique prevent you from contributing, other
     /*state and JS namespaces
 * is-: this indicates the state of the block or element. Most commonly used class is .is-active, like the active link in navigation. */
     /*hide Debug mode button, bust cache button, footer jquery, google page speed, when viewing site backend*/
+    .u-text-orange{
+        color:var(--buttonColor)!important;
+    }
 
     body.is-backend .u-hidden-backend {
         display: none;
@@ -502,7 +505,7 @@ Do not let fear of learning a new technique prevent you from contributing, other
                       <div class="dark-theme-toggle">
                         <label class="private-form__label private-form__label--small">
                           <i18n-string data-locale-at-render="en" data-key="DesignEditorsUI.customWidgetEditor.sidebar.fieldEdit.editorOptions.requiredLabel">
-                            Dark Theme
+                            <span class="u-text-orange">DM2</span> - Dark Theme
                           </i18n-string>
                           
                         </label>

--- a/popup.html
+++ b/popup.html
@@ -1,233 +1,245 @@
 <html>
+
 <head>
-	<title></title>
-	<style>
-/*To keep CSS organized and easy to understand this css is following this method https://css-tricks.com/combining-the-powers-of-sem-and-bio-for-improving-css/
+    <title></title>
+    <style>
+    /*To keep CSS organized and easy to understand this css is following this method https://css-tricks.com/combining-the-powers-of-sem-and-bio-for-improving-css/
 Do not let fear of learning a new technique prevent you from contributing, others can help convert your css to fit this flow. so pull request even if it doesn't fit this way of doing things. The important thing is that it works, keeping organized and understandable is second. If everyone finds they hate writing CSS this way we can work out another way to do it.
 */
-/*Settings - variables that do not generate visual styles on their own*/
-:root{
-  --buttonColor:#ff7a59;
-}
-:focus{outline:none;}
+    /*Settings - variables that do not generate visual styles on their own*/
 
-/*Objects - (namespace: o-) are used for design patterns, such as layouts, where items are being arranged rather than decorated. */
+     :root {
+        --buttonColor: #ff7a59;
+    }
 
-.o-menu-grid {
-  display: grid;
-  grid-gap: 5px;
+     :focus {
+        outline: none;
+    }
+    /*Objects - (namespace: o-) are used for design patterns, such as layouts, where items are being arranged rather than decorated. */
 
-  grid-template-columns: 1fr 1fr;
-  grid-template-areas:
-    "debug bustcache"
-    "movejquery movejquery"
-    "psrequest psrequest"
-    "docs docs";
-}
+    .o-menu-grid {
+        display: grid;
+        grid-gap: 5px;
 
-#hsDebug {
-  grid-area: debug;
-}
-#hsMoveJQueryToFooter {
-  grid-area: movejquery;
-}
-#bustCache {
-  grid-area: bustcache;
-}
-#psiScoreRequest {
-  grid-area: psrequest;
-}
-#docs{grid-area:docs;}
+        grid-template-columns: 1fr 1fr;
+        grid-template-areas: "debug bustcache" "movejquery movejquery" "psrequest psrequest" "docs docs";
+    }
 
+    #hsDebug {
+        grid-area: debug;
+    }
 
-.column_2 {
-  float: left;
-  width: 50%;
-}
+    #hsMoveJQueryToFooter {
+        grid-area: movejquery;
+    }
 
-.row:after {
-  content: "";
-  display: table;
-  clear: both;
-}
+    #bustCache {
+        grid-area: bustcache;
+    }
+
+    #psiScoreRequest {
+        grid-area: psrequest;
+    }
+
+    #docs {
+        grid-area: docs;
+    }
 
 
-/*Elements - HTML native elements default styles without classes*/
-* {
-  box-sizing: border-box;
-}
+    .column_2 {
+        float: left;
+        width: 50%;
+    }
 
-body {
-  width: 391px;
-  color: cornflowerblue;
-    background-color: #33475b;
-    background: linear-gradient(45deg,#33475b,#2d3e50);
-    margin:5px;/*evens context menu spacing to match grid gap*/
-}
-img {
-  max-width: 100%;
-  height: auto;
-}
+    .row:after {
+        content: "";
+        display: table;
+        clear: both;
+    }
+    /*Elements - HTML native elements default styles without classes*/
 
-/*Components - (namespace: c-) is a small feature that makes up a part of the website/extension. Think buttons, accordions, sliders, modal dialogs, etc. Each component is fully functional by itself and does not rely on any other components. This fact should be considered when you name the component.*/
+    * {
+        box-sizing: border-box;
+    }
 
-.c-btn {
-  padding:0;
-  height: 44px;
-  display: block;
-  width: 100%;
-  border: 3px solid var(--buttonColor);
-  font-size: 14px;
-  text-align: center;
-  text-decoration: none;
-  overflow: hidden;
-  cursor: pointer;
-  -webkit-appearance:none;
-  background-color:#fff;
-}
+    body {
+        width: 391px;
+        color: cornflowerblue;
+        background-color: #33475b;
+        background: linear-gradient(45deg, #33475b, #2d3e50);
+        margin: 5px;
+        /*evens context menu spacing to match grid gap*/
+    }
 
+    img {
+        max-width: 100%;
+        height: auto;
+    }
+    /*Components - (namespace: c-) is a small feature that makes up a part of the website/extension. Think buttons, accordions, sliders, modal dialogs, etc. Each component is fully functional by itself and does not rely on any other components. This fact should be considered when you name the component.*/
 
-
-
-.c-btn__face-primary,
-.c-btn__face-secondary {
-  display: block;
-  padding: 0 22px;
-  line-height: 39px;
-  transition: margin 0.4s;
-}
-.c-btn__face-primary {
-  background-color: var(--buttonColor);
-  color: #fff;
-}
-.c-btn:not(.c-btn--graded):hover .c-btn__face-primary,.c-btn:not(.c-btn--graded):focus .c-btn__face-primary {
-  margin-top: -39px;
-}
+    .c-btn {
+        padding: 0;
+        height: 44px;
+        display: block;
+        width: 100%;
+        border: 3px solid var(--buttonColor);
+        font-size: 14px;
+        text-align: center;
+        text-decoration: none;
+        overflow: hidden;
+        cursor: pointer;
+        -webkit-appearance: none;
+        background-color: #fff;
+    }
 
 
-.c-btn__psiScore {
-  display: none;
-  text-align: center;
-}
-
-.c-btn__grades {
-  font-size: 33px;
-  padding: 16px;
-  color: #e43;
-}
-
-.c-btn__score {/*update js*/
-  font-size: 40px;
-  display: block;
-  font-weight: bold;
-}
 
 
-/*Scopes - The purpose of the scope (namespace: s-) is to give us the highest specificity so we can overwrite any styles for a specific purpose.
+    .c-btn__face-primary,
+    .c-btn__face-secondary {
+        display: block;
+        padding: 0 22px;
+        line-height: 39px;
+        transition: margin 0.4s;
+    }
+
+    .c-btn__face-primary {
+        background-color: var(--buttonColor);
+        color: #fff;
+    }
+
+    .c-btn:not(.c-btn--graded):hover .c-btn__face-primary,
+    .c-btn:not(.c-btn--graded):focus .c-btn__face-primary {
+        margin-top: -39px;
+    }
+
+
+    .c-btn__psiScore {
+        display: none;
+        text-align: center;
+    }
+
+    .c-btn__grades {
+        font-size: 33px;
+        padding: 16px;
+        color: #e43;
+    }
+
+    .c-btn__score {
+        /*update js*/
+        font-size: 40px;
+        display: block;
+        font-weight: bold;
+    }
+    /*Scopes - The purpose of the scope (namespace: s-) is to give us the highest specificity so we can overwrite any styles for a specific purpose.
 
 */
-.c-btn--graded {/*update js to update the class it adds*/
-  overflow: initial;
-  height: initial;
-  /*background-image: url(https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/pagespeed-logo.png);*/
-  background-size: contain;
-  background-position: center bottom;
-  background-repeat: no-repeat;
-  background-size: 150px;
-}
 
-.c-btn--graded .c-btn__face-secondary {
-  display: none;
-}
+    .c-btn--graded {
+        /*update js to update the class it adds*/
+        overflow: initial;
+        height: initial;
+        /*background-image: url(https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/pagespeed-logo.png);*/
+        background-size: contain;
+        background-position: center bottom;
+        background-repeat: no-repeat;
+        background-size: 150px;
+    }
 
-.c-btn--docs{cursor:unset;}
-.c-btn--docs .c-btn__face-secondary{ 
-  display:flex;
-  align-items:center;
-  justify-content: space-around;
-}
-.c-btn--docs a{
-  padding:0 10px;
-}
-.c-btn--docs a:hover,.c-btn--docs a:focus{
-  color:var(--buttonColor); 
-  
-}
+    .c-btn--graded .c-btn__face-secondary {
+        display: none;
+    }
 
-/*Utility - Sometimes you may want to make changes only for a certain style in a specific place. In that case, utility (namespace: u-) classes can help us update it without changing the whole CSS structure.*/
+    .c-btn--docs {
+        cursor: unset;
+    }
 
-/*state and JS namespaces
+    .c-btn--docs .c-btn__face-secondary {
+        display: flex;
+        align-items: center;
+        justify-content: space-around;
+    }
+
+    .c-btn--docs a {
+        padding: 0 10px;
+    }
+
+    .c-btn--docs a:hover,
+    .c-btn--docs a:focus {
+        color: var(--buttonColor);
+    }
+    /*Utility - Sometimes you may want to make changes only for a certain style in a specific place. In that case, utility (namespace: u-) classes can help us update it without changing the whole CSS structure.*/
+    /*state and JS namespaces
 * is-: this indicates the state of the block or element. Most commonly used class is .is-active, like the active link in navigation. */
+    /*hide Debug mode button, bust cache button, footer jquery, google page speed, when viewing site backend*/
 
-/*hide Debug mode button, bust cache button, footer jquery, google page speed, when viewing site backend*/
-body.is-backend .u-hidden-backend{
-  display:none;
-}
+    body.is-backend .u-hidden-backend {
+        display: none;
+    }
 
-body.is-dm1 .u-hidden-dm1{
-  display:none;
-}
+    body.is-dm1 .u-hidden-dm1 {
+        display: none;
+    }
 
-body.is-dm2 .u-hidden-dm2{
-  display:none;
-}
-body.is-hs-docs .u-hidden-hs-docs{
-  display:none;
-}
-body.is-backend .o-menu-grid {
-  grid-template-columns: 1fr 1fr;
-  grid-template-areas:
-    "docs docs";
-}
+    body.is-dm2 .u-hidden-dm2 {
+        display: none;
+    }
 
-
-/*js-: this indicates that the specific element is bound to JavaScript events. For example, js-menu-click indicates that the element is bound to the click event. generally JS classes are only added to the html, as they are for targeting with JS not affecting actual styles.*/
-	</style>
+    body.is-hs-docs .u-hidden-hs-docs {
+        display: none;
+    }
+    /*js-: this indicates that the specific element is bound to JavaScript events. For example, js-menu-click indicates that the element is bound to the click event. generally JS classes are only added to the html, as they are for targeting with JS not affecting actual styles.*/
+    </style>
 </head>
+
 <body>
-	<div class="o-menu-grid">
-  
-      <button class="c-btn face-button js-click--debug u-hidden-backend" id="hsDebug">
-        <div class="c-btn__face-primary">Debug Mode</div>
-        <div class="c-btn__face-secondary">hsDebug=True</div>
-      </button>
-      <button class="c-btn face-button js-click--bust-cache u-hidden-backend" id="cacheBuster">
-        <div class="c-btn__face-primary">Bust Cache</div>
-        <div class="c-btn__face-secondary">bustCache=[random Number]</div>
-      </button>
-      <button class="c-btn face-button js-click--move-jquery-to-footer u-hidden-backend" id="hsMoveJQueryToFooter">
-        <div class="c-btn__face-primary">Footer jQuery</div>
-        <div class="c-btn__face-secondary">hsMoveJQueryToFooter=True</div>
-      </button>
-    
-
-
-    <button class="c-btn face-button js-click--psi-score-request u-hidden-backend" id="psiScoreRequest">
-      <div class="c-btn__face-primary">Google Page Speed Insights Scores</div>
-      <div class="c-btn__face-secondary">Score Me!<!--<img style="height: 39px;" src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/pagespeed.png">--></div>
-      <div class="row c-btn__grades">
-        <div class="c-btn__psiScore column_2" id="desktop_psi_placeholder">grading desktop...<!--<img src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/NewCorgiDance.gif">--></div>
-        <div class="c-btn__psiScore column_2" id="mobile_psi_placeholder">grading mobile...<!--<img src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/NewCorgiDance.gif">--></div>
-      </div>
-    </button>
-  </div>
-<div class="c-btn c-btn--docs face-button" id="docs">
-  <div class="c-btn__face-primary">Documentation</div>
-  <div class="c-btn__face-secondary">
-    <a target="blank" href="https://designers.hubspot.com/en/docs/hubl/hubl-supported-functions">Functions<!--add opens in new window icon--></a> 
-    <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-variables">Variables<!--add opens in new window icon--></a> <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-filters">Filters<!--add opens in new window icon--></a>
-    <a target="blank" href=" https://designers.hubspot.com/docs/tools/hubdb">HubDB<!--add opens in new window icon--></a>
-   
-  </div>
-</div>
-
-	
-<!-- 	<button id="psiScoreRequest" class="debugButton">Grade my page</button>
+    <div class="c-tab-slider">
+        <div class="c-tab-slider__tab" id="debug-tools">
+            <!--This tab will be focused when the user is not in the design manager -->
+            <div class="o-menu-grid">
+                <div class="o-menu-grid">
+                    <button class="c-btn face-button js-click--debug" id="hsDebug">
+                        <div class="c-btn__face-primary">Debug Mode</div>
+                        <div class="c-btn__face-secondary">hsDebug=True</div>
+                    </button>
+                    <button class="c-btn face-button js-click--bust-cache" id="cacheBuster">
+                        <div class="c-btn__face-primary">Bust Cache</div>
+                        <div class="c-btn__face-secondary">bustCache=[random Number]</div>
+                    </button>
+                    <button class="c-btn face-button js-click--move-jquery-to-footer" id="hsMoveJQueryToFooter">
+                        <div class="c-btn__face-primary">Footer jQuery</div>
+                        <div class="c-btn__face-secondary">hsMoveJQueryToFooter=True</div>
+                    </button>
+                    <button class="c-btn face-button js-click--psi-score-request" id="psiScoreRequest">
+                        <div class="c-btn__face-primary">Google Page Speed Insights Scores</div>
+                        <div class="c-btn__face-secondary">Score Me!
+                            <!--<img style="height: 39px;" src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/pagespeed.png">--></div>
+                        <div class="row c-btn__grades">
+                            <div class="c-btn__psiScore column_2" id="desktop_psi_placeholder">grading desktop...
+                                <!--<img src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/NewCorgiDance.gif">--></div>
+                            <div class="c-btn__psiScore column_2" id="mobile_psi_placeholder">grading mobile...
+                                <!--<img src="https://cdn2.hubspot.net/hubfs/2359872/Dev_Extension/NewCorgiDance.gif">--></div>
+                        </div>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="c-tab-slide" id="design-manager">
+            <!-- this tab will be focused while the user is in the design manager any features intended only for DM1 or DM2 should get disabled if they do not work in the current version of the design manager -->
+            <div class="c-btn c-btn--docs face-button" id="docs">
+                <div class="c-btn__face-primary">Documentation</div>
+                <div class="c-btn__face-secondary">
+                    <a target="blank" href="https://designers.hubspot.com/en/docs/hubl/hubl-supported-functions">Functions<!--add opens in new window icon--></a>
+                    <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-variables">Variables<!--add opens in new window icon--></a> <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-filters">Filters<!--add opens in new window icon--></a>
+                    <a target="blank" href=" https://designers.hubspot.com/docs/tools/hubdb">HubDB<!--add opens in new window icon--></a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!--  <button id="psiScoreRequest" class="debugButton">Grade my page</button>
  -->
-
-	
-
-	<script src="jquery-3.2.1.min.js"></script>
-	<script src="popup.js"></script>
+    <script src="jquery-3.2.1.min.js"></script>
+    <script src="popup.js"></script>
 </body>
+
 </html>

--- a/popup.html
+++ b/popup.html
@@ -26,10 +26,12 @@ Do not let fear of learning a new technique prevent you from contributing, other
         grid-template-areas: "debug bustcache" "movejquery amp" "psrequest psrequest";
         /*margin-right: 5px;*/
     }
-    .o-menu-grid--debug{
+
+    .o-menu-grid--debug {
         grid-template-areas: "debug bustcache" "movejquery amp" "psrequest psrequest";
     }
-    .o-menu-grid--design-manager{
+
+    .o-menu-grid--design-manager {
         grid-template-areas: "docs docs";
     }
 
@@ -79,8 +81,7 @@ Do not let fear of learning a new technique prevent you from contributing, other
         color: cornflowerblue;
         background-color: #33475b;
         background: linear-gradient(45deg, #33475b, #2d3e50);
-        margin:0;
-        
+        margin: 0;
     }
 
     img {
@@ -102,34 +103,38 @@ Do not let fear of learning a new technique prevent you from contributing, other
         font-size: 13px;
         text-transform: uppercase;
         font-weight: bold;
-        border-bottom:5px transparent solid;
+        border-bottom: 5px transparent solid;
     }
 
     .c-tab-slider__controls {
         display: flex;
     }
+
     .c-tab-slider__tab {
         display: block;
         width: 100vw;
-        padding:5px;
-
+        padding: 5px;
     }
 
     .c-tab-slider__track {
         display: flex;
         flex-flow: row;
-        position:relative;
+        position: relative;
         -webkit-transition: all 600ms cubic-bezier(0.77, 0, 0.175, 1);
-        transition:         all 600ms cubic-bezier(0.77, 0, 0.175, 1);
+        transition: all 600ms cubic-bezier(0.77, 0, 0.175, 1);
     }
-    .c-tab-slider--state-design-manager .c-tab-slider__track{
-        left:-100vw;
+
+    .c-tab-slider--state-design-manager .c-tab-slider__track {
+        left: -100vw;
     }
-    .c-tab-slider--state-design-manager .c-tab-slider__tab-selector--develop,.c-tab-slider--state-debug .c-tab-slider__tab-selector--debug{
-      border-bottom-color:var(--buttonColor);
+
+    .c-tab-slider--state-design-manager .c-tab-slider__tab-selector--develop,
+    .c-tab-slider--state-debug .c-tab-slider__tab-selector--debug {
+        border-bottom-color: var(--buttonColor);
     }
-    .c-tab-slider--state-debug  .c-tab-slider__track{
-        left:0;
+
+    .c-tab-slider--state-debug .c-tab-slider__track {
+        left: 0;
     }
 
     .c-btn {
@@ -254,10 +259,10 @@ Do not let fear of learning a new technique prevent you from contributing, other
 
 <body>
     <div class="c-tab-slider">
-      <div class="c-tab-slider__controls">
-        <button class="c-tab-slider__tab-selector js-click--tab-debug c-tab-slider__tab-selector--debug">Debug</button>
-        <button class="c-tab-slider__tab-selector c-tab-slider__tab-selector--develop js-click--tab-develop">Develop</button>
-      </div>
+        <div class="c-tab-slider__controls">
+            <button class="c-tab-slider__tab-selector js-click--tab-debug c-tab-slider__tab-selector--debug">Debug</button>
+            <button class="c-tab-slider__tab-selector c-tab-slider__tab-selector--develop js-click--tab-develop">Develop</button>
+        </div>
         <div class="c-tab-slider__track c-tab-slider--state-debug">
             <div class="c-tab-slider__tab" id="debug-tools">
                 <!--This tab will be focused when the user is not in the design manager -->
@@ -293,12 +298,14 @@ Do not let fear of learning a new technique prevent you from contributing, other
             </div>
             <div class="c-tab-slider__tab" id="design-manager">
                 <!-- this tab will be focused while the user is in the design manager any features intended only for DM1 or DM2 should get disabled if they do not work in the current version of the design manager -->
-                <div class="c-btn c-btn--docs face-button" id="docs">
-                    <div class="c-btn__face-primary">Documentation</div>
-                    <div class="c-btn__face-secondary">
-                        <a target="blank" href="https://designers.hubspot.com/en/docs/hubl/hubl-supported-functions">Functions<!--add opens in new window icon--></a>
-                        <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-variables">Variables<!--add opens in new window icon--></a> <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-filters">Filters<!--add opens in new window icon--></a>
-                        <a target="blank" href=" https://designers.hubspot.com/docs/tools/hubdb">HubDB<!--add opens in new window icon--></a>
+                <div class="o-menu-grid o-menu-grid--design-manager">
+                    <div class="c-btn c-btn--docs face-button" id="docs">
+                        <div class="c-btn__face-primary">Documentation</div>
+                        <div class="c-btn__face-secondary">
+                            <a target="blank" href="https://designers.hubspot.com/en/docs/hubl/hubl-supported-functions">Functions<!--add opens in new window icon--></a>
+                            <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-variables">Variables<!--add opens in new window icon--></a> <a target="blank" href="https://designers.hubspot.com/docs/hubl/hubl-supported-filters">Filters<!--add opens in new window icon--></a>
+                            <a target="blank" href=" https://designers.hubspot.com/docs/tools/hubdb">HubDB<!--add opens in new window icon--></a>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/popup.html
+++ b/popup.html
@@ -22,7 +22,7 @@ Do not let fear of learning a new technique prevent you from contributing, other
         grid-gap: 5px;
 
         grid-template-columns: 1fr 1fr;
-        grid-template-areas: "debug bustcache" "movejquery movejquery" "psrequest psrequest" "docs docs";
+        grid-template-areas: "debug bustcache" "movejquery amp" "psrequest psrequest" "docs docs";
     }
 
     #hsDebug {
@@ -31,6 +31,10 @@ Do not let fear of learning a new technique prevent you from contributing, other
 
     #hsMoveJQueryToFooter {
         grid-area: movejquery;
+    }
+
+    #hs_amp {
+        grid-area: amp;
     }
 
     #bustCache {
@@ -106,6 +110,11 @@ Do not let fear of learning a new technique prevent you from contributing, other
     .c-btn__face-primary {
         background-color: var(--buttonColor);
         color: #fff;
+    }
+
+    .c-btn__face-secondary {
+        font-size: 13px;
+        padding: 0 0;
     }
 
     .c-btn:not(.c-btn--graded):hover .c-btn__face-primary,
@@ -209,6 +218,10 @@ Do not let fear of learning a new technique prevent you from contributing, other
                     <button class="c-btn face-button js-click--move-jquery-to-footer" id="hsMoveJQueryToFooter">
                         <div class="c-btn__face-primary">Footer jQuery</div>
                         <div class="c-btn__face-secondary">hsMoveJQueryToFooter=True</div>
+                    </button>
+                    <button class="c-btn face-button js-click--amp" id="hs_amp">
+                        <div class="c-btn__face-primary">Amp</div>
+                        <div class="c-btn__face-secondary">hs_amp=true</div>
                     </button>
                     <button class="c-btn face-button js-click--psi-score-request" id="psiScoreRequest">
                         <div class="c-btn__face-primary">Google Page Speed Insights Scores</div>

--- a/popup.js
+++ b/popup.js
@@ -43,6 +43,7 @@ var developerTools = {
 		console.log("Set Menu Context run");
 		
 		chrome.tabs.getSelected(null, function(tab) {
+			/*getSelected might be deprecated need to review*/
 			var tabUrl = tab.url;
 			console.log("Current URL: ",tabUrl);
 			if(~tabUrl.indexOf("app.hubspot.com")){

--- a/popup.js
+++ b/popup.js
@@ -78,7 +78,7 @@ var developerTools = {
 	onLoad: function() {
 		developerTools.setMenuContext();
 
-		$('.js-click--debug,.js-click--move-jquery-to-footer,.js-click--bust-cache').click(function () {
+		$('.js-click--debug,.js-click--move-jquery-to-footer,.js-click--bust-cache,.js-click--amp').click(function () {
 			developerTools.debugReload($(this).attr('id'));
 		});
 		

--- a/popup.js
+++ b/popup.js
@@ -50,6 +50,11 @@ var developerTools = {
 				if(~tabUrl.indexOf("/design-manager/")){
 					console.log("Old Design Manager is active");
 				}
+				if(~tabUrl.indexOf("/beta-design-manager/")){
+					/*note this string detection will likely break once rolled out to everyone as they likely wont leave beta in the name*/
+					console.log("Design Manager V2 is active");
+				}
+				
 			}
 			
 

--- a/popup.js
+++ b/popup.js
@@ -78,8 +78,42 @@ var developerTools = {
 		
 		
 	},
+	saveSettings:function(){
+		// Saves settings to chrome.storage
+
+
+		  var darkthemeVal = document.getElementById('darktheme').checked;
+		  chrome.storage.sync.set({
+		    darktheme: darkthemeVal,
+		  }, function() {
+		    // Update status to let user know options were saved.
+		    var status = document.getElementById('status');
+		    status.textContent = 'Options saved. If you have the Design manager open, you will need to refresh to see the theme.';
+		    setTimeout(function() {
+		      status.textContent = '';
+		    }, 4000);
+		  });
+
+
+
+
+  
+
+
+	},
+	getSettings:function(){
+		chrome.storage.sync.get(['darktheme'], function(items) {
+			// Restores select box and checkbox state using the preferences
+// stored in chrome.storage.
+    		document.getElementById('darktheme').checked = items.darktheme;
+  		});
+
+	},
 	onLoad: function() {
 		developerTools.setMenuContext();
+		document.addEventListener('DOMContentLoaded', developerTools.getSettings);
+		document.getElementById('save').addEventListener('click',
+    developerTools.saveSettings);
 
 		$('.js-click--debug,.js-click--move-jquery-to-footer,.js-click--bust-cache,.js-click--amp').click(function () {
 			developerTools.debugReload($(this).attr('id'));

--- a/popup.js
+++ b/popup.js
@@ -1,3 +1,4 @@
+
 var developerTools = {
 
 	debugReload: function(debugParam) {
@@ -48,14 +49,25 @@ var developerTools = {
 			console.log("Current URL: ",tabUrl);
 			if(~tabUrl.indexOf("app.hubspot.com")){
 				console.log("This is the hubspot backend.");
+				$('body').addClass("is-backend"); //indicates user is seeing HS backend
 				if(~tabUrl.indexOf("/design-manager/")){
 					console.log("Old Design Manager is active");
+					$('body').addClass("is-dm1");//indicates user is seeing design manager v1
 				}
 				if(~tabUrl.indexOf("/beta-design-manager/")){
 					/*note this string detection will likely break once rolled out to everyone as they likely wont leave beta in the name*/
 					console.log("Design Manager V2 is active");
+					$('body').addClass("is-dm2");//indicates user is seeing design manager v2
 				}
 				
+			}
+			else if(~tabUrl.indexOf("designers.hubspot.com/docs/")){
+				console.log("Viewing HubSpot Documentation");
+				$('body').addClass("is-hs-docs");
+			}
+			else{
+				console.log("This is not in the HubSpot Backend");
+
 			}
 			
 

--- a/popup.js
+++ b/popup.js
@@ -81,8 +81,9 @@ var developerTools = {
 	saveSettings:function(){
 		// Saves settings to chrome.storage
 
-
-		  var darkthemeVal = document.getElementById('darktheme').checked;
+		  console.log("settings saved");
+		  var darkthemeVal = $('#darktheme').prop('checked');
+		  console.log("dark theme is ",darkthemeVal);
 		  chrome.storage.sync.set({
 		    darktheme: darkthemeVal,
 		  }, function() {
@@ -106,14 +107,19 @@ var developerTools = {
 			// Restores select box and checkbox state using the preferences
 // stored in chrome.storage.
     		document.getElementById('darktheme').checked = items.darktheme;
+    		console.log("dark theme:",items.darktheme);
+    		if(items.darktheme){
+    			$('.dark-theme-toggle .uiToggleSwitch').addClass("uiToggleSwitchOn private-form__toggle-switch--on");
+    		}
   		});
 
 	},
 	onLoad: function() {
 		developerTools.setMenuContext();
-		document.addEventListener('DOMContentLoaded', developerTools.getSettings);
+		developerTools.getSettings();
+		/*document.addEventListener('DOMContentLoaded', developerTools.getSettings());
 		document.getElementById('save').addEventListener('click',
-    developerTools.saveSettings);
+    developerTools.saveSettings());*/
 
 		$('.js-click--debug,.js-click--move-jquery-to-footer,.js-click--bust-cache,.js-click--amp').click(function () {
 			developerTools.debugReload($(this).attr('id'));
@@ -136,6 +142,12 @@ var developerTools = {
 			$('.c-tab-slider').removeClass("c-tab-slider--state-debug");
 			$('.c-tab-slider').addClass('c-tab-slider--state-design-manager');
 		});
+		$('.dark-theme-toggle input').change(function(){
+
+			developerTools.saveSettings();
+			$('.dark-theme-toggle .uiToggleSwitch').toggleClass("uiToggleSwitchOn private-form__toggle-switch--on");
+		});
+
 
 	}
 

--- a/popup.js
+++ b/popup.js
@@ -39,8 +39,26 @@ var developerTools = {
 			});
 		});
 	},
+	setMenuContext:function(){
+		console.log("Set Menu Context run");
+		
+		chrome.tabs.getSelected(null, function(tab) {
+			var tabUrl = tab.url;
+			console.log("Current URL: ",tabUrl);
+			if(~tabUrl.indexOf("app.hubspot.com")){
+				console.log("This is the hubspot backend.");
+				if(~tabUrl.indexOf("/design-manager/")){
+					console.log("Old Design Manager is active");
+				}
+			}
+			
 
+		});
+		
+		
+	},
 	onLoad: function() {
+		developerTools.setMenuContext();
 
 		$('.js-click--debug,.js-click--move-jquery-to-footer,.js-click--bust-cache').click(function () {
 			developerTools.debugReload($(this).attr('id'));

--- a/popup.js
+++ b/popup.js
@@ -50,6 +50,7 @@ var developerTools = {
 			if(~tabUrl.indexOf("app.hubspot.com")){
 				console.log("This is the hubspot backend.");
 				$('body').addClass("is-backend"); //indicates user is seeing HS backend
+				$('.c-tab-slider').addClass('c-tab-slider--state-design-manager');
 				if(~tabUrl.indexOf("/design-manager/")){
 					console.log("Old Design Manager is active");
 					$('body').addClass("is-dm1");//indicates user is seeing design manager v1
@@ -64,9 +65,11 @@ var developerTools = {
 			else if(~tabUrl.indexOf("designers.hubspot.com/docs/")){
 				console.log("Viewing HubSpot Documentation");
 				$('body').addClass("is-hs-docs");
+				$('.c-tab-slider').addClass('c-tab-slider--state-debug');
 			}
 			else{
 				console.log("This is not in the HubSpot Backend");
+				$('.c-tab-slider').addClass('c-tab-slider--state-debug');
 
 			}
 			
@@ -89,6 +92,16 @@ var developerTools = {
 			$(".js-click--psi-score-request").addClass("c-btn--graded"); 
 		});
 		
+		$('.js-click--tab-debug').click(function(){
+			console.log("debug");
+			$('.c-tab-slider').removeClass("c-tab-slider--state-design-manager");
+			$('.c-tab-slider').addClass('c-tab-slider--state-debug');
+		});
+		$('.js-click--tab-develop').click(function(){
+			console.log("develop");
+			$('.c-tab-slider').removeClass("c-tab-slider--state-debug");
+			$('.c-tab-slider').addClass('c-tab-slider--state-design-manager');
+		});
 
 	}
 


### PR DESCRIPTION
Hey guys wanted you to see this update before I push it to everyone as you guys may have some feedback since it's kind of a big change.

Right now the tabs are kinda rudimentarily set up I focused on making them work, later when more tabs get added a better way of handling it can easily be set up.

I organized the tabs as Debug and Develop. You're welcome to suggest new names, it was hard enough coming up with those.

The tabs are auto-focused based on the page you are currently viewing.

The dark theme now only applies to Design Manager 2.(since it's not really designed for DM1). The toggle for the dark theme is now moved to the develop tab. I also stylized it to look like the HubSpot toggles. There is no save button anymore, the settings get saved immediately.

I added the AMP button for testing amp enabled pages.

I haven't been able to figure out why the Google Page Speed issue is occurring(can only run it once).

Seeing as the current version of the extension has that issue and no one is complaining - I think it'd be okay to push these updates live and fix that later in a patch or future version if you guys can't figure it out.
