### PR TITLE
Fix for Issue 133 - Placed call ceiling on waitForEl()

### DIFF
--- a/design-manager.js
+++ b/design-manager.js
@@ -6,16 +6,23 @@ $(document).ready(function() {
     var devMenu = false;
 
     var waitForEl = function(selector, callback) {
-    /*This needs to be modified to not run forever if item is never detected.*/
-    	
-      if ($(selector).text().length) {
-        callback();
-      } else {
-        setTimeout(function() {
-          waitForEl(selector, callback);
-        }, 100);
-      }
-    };
+      /*Will poll for element only 10 times before stopping*/
+      var timesPolled = 0;
+        
+        (function waiting(){
+          if (timesPolled < 10){
+            if ($(selector).text().length) {
+              callback();
+            } else {
+              setTimeout(function() {
+                timesPolled++;
+                waiting(selector, callback);
+              }, 100);
+            }
+          }
+          /*Next steps - add error handling here when polling fails*/
+        })();
+      };
 
     function setTitle(siteName){
         document.title = siteName.replace("www.","")+"|DM-HS";


### PR DESCRIPTION
Associated issue #133 

### Summary
- Wrapped logic inside `waitForEl` in an IIFE, along with a counter (and a sniff for that counter).
- Closure of `timesPolled` will ensure that polling stops after **10 times** of no detection