### PR TITLE
Use hsCacheBuster query string

### DIFF
--- a/background.js
+++ b/background.js
@@ -39,7 +39,7 @@ chrome.commands.onCommand.addListener(function(command) {
     console.log("Command:", command);
     if (command === "bust-cache") {
         console.log("Cache bustato");
-        _gaq.push(["_trackEvent", "cacheBuster", "kbShortcutUsed"]);
+        _gaq.push(["_trackEvent", "hsCacheBuster", "kbShortcutUsed"]);
 
 
 
@@ -49,7 +49,7 @@ chrome.commands.onCommand.addListener(function(command) {
             var tabUrl = new URL(tabs[0].url);
             var params = new URLSearchParams(tabUrl.search);
             var randomNum = Math.floor(Math.random() * 9999) + 1;
-            params.set("cacheBuster", randomNum);
+            params.set("hsCacheBuster", randomNum);
 
 
             chrome.tabs.update(tabs[0].id, { url: tabUrl.origin + tabUrl.pathname + '?' + params.toString() });

--- a/popup.html
+++ b/popup.html
@@ -503,7 +503,7 @@ Do not let fear of learning a new technique prevent you from contributing, other
                         <div class="c-btn__face-primary" data-i18n="debugButton"><!--Debug Mode--></div>
                         <div class="c-btn__face-secondary">hsDebug=True</div>
                     </button>
-                    <button class="c-btn face-button js-click--bust-cache" id="cacheBuster">
+                    <button class="c-btn face-button js-click--bust-cache" id="hsCacheBuster">
                         <div class="c-btn__face-primary" data-i18n="cacheBustButton"><!--Bust Cache--></div>
                         <div class="c-btn__face-secondary">hsBustCache=[random #]</div>
                     </button>

--- a/popup.html
+++ b/popup.html
@@ -505,7 +505,7 @@ Do not let fear of learning a new technique prevent you from contributing, other
                     </button>
                     <button class="c-btn face-button js-click--bust-cache" id="cacheBuster">
                         <div class="c-btn__face-primary" data-i18n="cacheBustButton"><!--Bust Cache--></div>
-                        <div class="c-btn__face-secondary">bustCache=[random Number]</div>
+                        <div class="c-btn__face-secondary">hsBustCache=[random #]</div>
                     </button>
                     <button class="c-btn face-button js-click--move-jquery-to-footer" id="hsMoveJQueryToFooter">
                         <div class="c-btn__face-primary" data-i18n="footerJqueryButton"><!--Footer jQuery--></div>

--- a/popup.js
+++ b/popup.js
@@ -32,7 +32,7 @@ var developerTools = {
 
             if (debugParam === "cacheBuster") {
                 var randomNum = Math.floor(Math.random() * 9999) + 1;
-                params.set("cacheBuster", randomNum);
+                params.set("hsCacheBuster", randomNum);
             } else if (params.has(debugParam)) {
                 params.delete(debugParam);
             } else {

--- a/popup.js
+++ b/popup.js
@@ -30,7 +30,7 @@ var developerTools = {
 
             trackClick(debugParam);
 
-            if (debugParam === "cacheBuster") {
+            if (debugParam === "hsCacheBuster") {
                 var randomNum = Math.floor(Math.random() * 9999) + 1;
                 params.set("hsCacheBuster", randomNum);
             } else if (params.has(debugParam)) {


### PR DESCRIPTION
Start using the query string `hsCacheBuster` rather than `cacheBuster` to ensure this functionality continues to work after some new site speed optimization improvements soon to come... 😉 

I updated the popup html to be `hsBustCache=[random #]` which fits better with the longer name. 

@TheWebTech sorry I am a little out of touch - what is this stuff doing exactly? https://github.com/williamspiro/HubSpot-Developer-Extension/blob/master/background.js#L42-L52 Should I update this as well to use `hsCacheBuster` rather than `cacheBuster`, or leave it? 