### PR TITLE
Hotfix developer menu

### DIFF
--- a/design-manager.js
+++ b/design-manager.js
@@ -316,7 +316,7 @@ $(document).ready(function() {
                 /*get current HubSpot ID*/
                 var hubId;
                 waitForEl(".navtools", function () {
-                    hubId = $(".navtools .settings > #navSetting").attr("href").split("/user-preferences/")[1].split("?")[0];
+                    hubId = document.getElementsByClassName("navAccount-portalId")[0].textContent;
                     /*inject dev menu*/
                     generateDevMenu(hubId);
                 });


### PR DESCRIPTION
HubSpot updated the container for the account ID. This change updates to the new selector, and also removes the jQuery dependency for this trivial feature.

This issue was causing the developer menu to not display.

I have not yet tested that this is the only update needed to restore the developer menu. It's possible other HTML has changed requiring more updates to the generation of the developer menu.


Your checklist for this pull request
🚨Please review the guidelines for contributing to this repository.

[x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Do not pull request to Master please.(when in doubt request Develop branch)
[] Test to make sure your feature/bugfix doesn't break other features ;)
[x] Write a meaningful description of what your changes are.
[] Wait patiently and celebrate, you've submitted changes to the extension!
